### PR TITLE
Add Hugo site for Local Pest Co

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+# Ignore Hugo build output
+public/
+resources/
+
+# OS files
+.DS_Store
+
+# log files
+*.log
+# Hugo build lock file
+.hugo_build.lock

--- a/archetypes/default.md
+++ b/archetypes/default.md
@@ -1,0 +1,5 @@
++++
+title = '{{ replace .File.ContentBaseName "-" " " | title }}'
+date = {{ .Date }}
+draft = true
++++

--- a/content/_index.md
+++ b/content/_index.md
@@ -1,0 +1,9 @@
++++
+title = "Local Pest Co"
++++
+
+Local Pest Co is an Aboriginal-owned pest control service based in Kingscliff.
+We offer prompt, eco-conscious solutions for termites, rodents, ants, and other
+pests for homes and businesses across the Tweed Coast.
+
+Call 0405 508 035 for same or next-day service.

--- a/content/about.md
+++ b/content/about.md
@@ -1,0 +1,6 @@
++++
+title = "About"
++++
+
+Founded and operated by Aboriginal locals, Local Pest Co combines community knowledge with licensed pest management techniques.
+We focus on safe methods that respect families, pets, and the environment.

--- a/content/contact.md
+++ b/content/contact.md
@@ -1,0 +1,8 @@
++++
+title = "Contact"
++++
+
+Phone: 0405 508 035  
+Email: [info@localpest.co](mailto:info@localpest.co)
+
+We serve Kingscliff, the Tweed Coast, and nearby regions. Get in touch to arrange a visit or request a quote.

--- a/content/services.md
+++ b/content/services.md
@@ -1,0 +1,12 @@
++++
+title = "Our Services"
++++
+
+We handle common pest issues with targeted treatments:
+
+- Termite inspections and treatment programs
+- Rodent management
+- Cockroach and ant solutions
+- Spider control
+
+Every visit includes practical advice for prevention.

--- a/hugo.toml
+++ b/hugo.toml
@@ -1,0 +1,4 @@
+baseURL = '/'
+languageCode = 'en-us'
+title = 'Local Pest Co'
+disableKinds = ['taxonomy', 'term']

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ .Title }} - {{ .Site.Title }}{{ end }}</title>
+</head>
+<body>
+  <header>
+    <h1><a href="{{ "/" | relURL }}">{{ .Site.Title }}</a></h1>
+    <nav>
+      <a href="{{ "/" | relURL }}">Home</a>
+      <a href="{{ "/services/" | relURL }}">Services</a>
+      <a href="{{ "/about/" | relURL }}">About</a>
+      <a href="{{ "/contact/" | relURL }}">Contact</a>
+    </nav>
+  </header>
+  <main>
+    {{ block "main" . }}{{ end }}
+  </main>
+  <footer>
+    <p>&copy; {{ now.Format "2006" }} {{ .Site.Title }}</p>
+  </footer>
+</body>
+</html>

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,0 +1,5 @@
+{{ define "main" }}
+<article>
+  {{ .Content }}
+</article>
+{{ end }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,0 +1,5 @@
+{{ define "main" }}
+<section>
+  {{ .Content }}
+</section>
+{{ end }}


### PR DESCRIPTION
## Summary
- initialize Hugo site configuration
- add homepage, services, about, and contact content inspired by Local Pest Co
- create basic layouts and navigation

## Testing
- `hugo`

------
https://chatgpt.com/codex/tasks/task_e_68be2757c0dc83258c235842b0d0ea16