### PR TITLE
chore: require Hugo 0.146.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # localpestco
+
+This site is built with [Hugo](https://gohugo.io/) and requires version `0.146.0` or later.

--- a/hugo.toml
+++ b/hugo.toml
@@ -1,4 +1,5 @@
 baseURL = '/'
 languageCode = 'en-us'
 title = 'Local Pest Co'
+min_version = '0.146.0'
 disableKinds = ['taxonomy', 'term']


### PR DESCRIPTION
## Summary
- require Hugo version 0.146.0 in site configuration
- document required Hugo version in README

## Testing
- `/tmp/hugo-install/hugo version`
- `/tmp/hugo-install/hugo --destination /tmp/public`


------
https://chatgpt.com/codex/tasks/task_e_68be2d03fe688325beee21d0efb072b4