### PR TITLE
Add Kingscliff area location pages and site styling

### DIFF
--- a/content/locations/_index.md
+++ b/content/locations/_index.md
@@ -1,0 +1,6 @@
++++
+title = "Locations Around Kingscliff"
+description = "Pest control services in Kingscliff and nearby areas."
++++
+
+We provide eco-friendly pest control across the Tweed Coast. Choose your area below.

--- a/content/locations/cabarita-beach.md
+++ b/content/locations/cabarita-beach.md
@@ -1,0 +1,10 @@
++++
+title = "Cabarita Beach"
+description = "Pest control services for Cabarita Beach."
++++
+
+<div class="hero">Cabarita Beach hero placeholder</div>
+
+We handle termites, rodents, and other pests for Cabarita Beach properties.
+
+<div class="placeholder-box"></div>

--- a/content/locations/casuarina.md
+++ b/content/locations/casuarina.md
@@ -1,0 +1,10 @@
++++
+title = "Casuarina"
+description = "Pest control services for Casuarina."
++++
+
+<div class="hero">Casuarina hero placeholder</div>
+
+Protecting Casuarina homes and businesses with safe, effective pest treatments.
+
+<div class="placeholder-box"></div>

--- a/content/locations/fingal-head.md
+++ b/content/locations/fingal-head.md
@@ -1,0 +1,10 @@
++++
+title = "Fingal Head"
+description = "Pest control services for Fingal Head."
++++
+
+<div class="hero">Fingal Head hero placeholder</div>
+
+Our technicians help Fingal Head residents stay pest-free year round.
+
+<div class="placeholder-box"></div>

--- a/content/locations/kingscliff.md
+++ b/content/locations/kingscliff.md
@@ -1,0 +1,10 @@
++++
+title = "Kingscliff"
+description = "Local pest control services in Kingscliff."
++++
+
+<div class="hero">Kingscliff hero placeholder</div>
+
+Our Kingscliff team delivers eco-friendly pest control for homes and businesses.
+
+<div class="placeholder-box"></div>

--- a/hugo.toml
+++ b/hugo.toml
@@ -1,6 +1,6 @@
 baseURL = '/'
 languageCode = 'en-us'
 title = 'Local Pest Co'
-theme = 'PaperMod'
+# theme removed to use custom layouts
 min_version = '0.146.0'
 disableKinds = ['taxonomy', 'term']

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ .Title }} - {{ .Site.Title }}{{ end }}</title>
   {{ with .Params.description }}
   <meta name="description" content="{{ . }}">
@@ -9,6 +10,7 @@
   {{ with .Params.keywords }}
   <meta name="keywords" content="{{ delimit . ", " }}">
   {{ end }}
+  <link rel="stylesheet" href="{{ "/css/style.css" | relURL }}">
 </head>
 <body>
   <header>
@@ -16,6 +18,7 @@
     <nav>
       <a href="{{ "/" | relURL }}">Home</a>
       <a href="{{ "/services/" | relURL }}">Services</a>
+      <a href="{{ "/locations/" | relURL }}">Locations</a>
       <a href="{{ "/about/" | relURL }}">About</a>
       <a href="{{ "/contact/" | relURL }}">Contact</a>
     </nav>

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,0 +1,10 @@
+{{ define "main" }}
+<section>
+  <h2>{{ .Title }}</h2>
+  <ul>
+    {{ range .Pages }}
+    <li><a href="{{ .RelPermalink }}">{{ .Title }}</a></li>
+    {{ end }}
+  </ul>
+</section>
+{{ end }}

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1,0 +1,36 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 0;
+  padding: 0;
+}
+
+header, footer {
+  background-color: #f0f0f0;
+  padding: 1rem;
+}
+
+nav a {
+  margin-right: 1rem;
+  text-decoration: none;
+  color: #333;
+}
+
+main {
+  padding: 1rem;
+}
+
+.hero {
+  width: 100%;
+  height: 250px;
+  background-color: #ddd;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #666;
+}
+
+.placeholder-box {
+  width: 100%;
+  height: 200px;
+  background-color: #eee;
+}


### PR DESCRIPTION
## Summary
- Add basic site CSS and navigation link for new Locations section
- Create Kingscliff and surrounding area location pages with placeholder hero sections
- Include list template and remove unused theme configuration

## Testing
- `hugo >/tmp/hugo.log && tail -n 20 /tmp/hugo.log`

------
https://chatgpt.com/codex/tasks/task_e_68be354e9b6c8325878ab118d1f7c840