### PR TITLE
feat: add SEO and analytics scaffolding

### DIFF
--- a/.github/workflows/seo.yml
+++ b/.github/workflows/seo.yml
@@ -1,0 +1,21 @@
+name: seo
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: peaceiris/actions-hugo@v2
+        with:
+          hugo-version: 'latest'
+          extended: true
+      - run: hugo --gc --minify
+      - run: |
+          npm install -g htmltest html-validate@8 lighthouse-ci@0
+          htmltest || true
+          html-validate "public/**/*.html" || true
+          lhci autorun || true

--- a/SEO_GUIDE.md
+++ b/SEO_GUIDE.md
@@ -1,0 +1,35 @@
+# SEO Guide
+
+## Front Matter Fields
+
+| Key | Description | Default |
+| --- | --- | --- |
+| `title` | Page title | required |
+| `meta_desc` | Meta description | from summary or site param |
+| `slug` | URL slug | generated from title |
+| `aliases` | Legacy paths for 301 redirects | [] |
+| `draft` | If true, page excluded | `false` |
+| `date` | Publish date | file mtime |
+| `lastmod` | Last modified date | file mtime |
+| `tags`/`categories` | Taxonomy terms | [] |
+| `canonical` | Override canonical URL | computed |
+| `robots` | Custom robots directive | `index,follow` |
+| `images` | Array of image paths | [] |
+| `social_image` | Image used for social cards | first item in `images` |
+| `schema` | Additional schema properties | {} |
+| `noindex` | Boolean shortcut for `noindex,follow` | `false` |
+
+## Redirects
+
+- Per-page: set `aliases` in front matter.
+- Global `_redirects` file: create `static/_redirects` with one rule per line.
+
+## Testing
+
+Run locally before deploying:
+
+```bash
+hugo --gc --minify
+htmltest || true
+html-validate public/**/*.html || true
+```

--- a/hugo.toml
+++ b/hugo.toml
@@ -1,6 +1,31 @@
-baseURL = '/'
+baseURL = 'https://www.example.com/'
 languageCode = 'en-us'
 title = 'Local Pest Co'
 # theme removed to use custom layouts
 min_version = '0.146.0'
 disableKinds = ['taxonomy', 'term']
+
+[outputs]
+home = ['HTML', 'RSS', 'Robots']
+
+[outputFormats]
+  [outputFormats.Robots]
+    mediaType = 'text/plain'
+    baseName = 'robots'
+    isPlainText = true
+
+[sitemap]
+  changefreq = 'weekly'
+  filename = 'sitemap.xml'
+  priority = 0.5
+
+[params]
+  # canonical production URL used for canonicals and sitemap
+  productionBaseURL = 'https://www.example.com/'
+  # optional title suffix appended to page titles
+  titleSuffix = ''
+  # Google Analytics ID (GA4)
+  ga_id = ''
+  # social accounts
+  [params.social]
+    twitter = ''

--- a/layouts/404.html
+++ b/layouts/404.html
@@ -1,0 +1,4 @@
+{{ define "main" }}
+<h1>Page Not Found</h1>
+<p>We couldn't find what you're looking for. Return to <a href="{{ "/" | relURL }}">home</a> or use the navigation above.</p>
+{{ end }}

--- a/layouts/_default/_markup/render-image.html
+++ b/layouts/_default/_markup/render-image.html
@@ -1,0 +1,18 @@
+{{- $alt := .Text | plainify -}}
+{{- if eq (len $alt) 0 -}}{{ warnf "Image missing alt text: %s" .Destination }}{{- end -}}
+{{- $title := .Title -}}
+{{- $img := .Page.Resources.GetMatch (printf "%s" .Destination) -}}
+{{- if $img -}}
+  {{- $large := $img.Fit "1200x" -}}
+  {{- $medium := $img.Fit "800x" -}}
+  {{- $small := $img.Fit "400x" -}}
+  {{- $avif := $large.Resize "1200x q75 avif" -}}
+  {{- $webp := $large.Resize "1200x q75 webp" -}}
+  <picture>
+    <source srcset="{{ $avif.RelPermalink }}" type="image/avif">
+    <source srcset="{{ $webp.RelPermalink }}" type="image/webp">
+    <img src="{{ $large.RelPermalink }}" srcset="{{ $small.RelPermalink }} 400w, {{ $medium.RelPermalink }} 800w, {{ $large.RelPermalink }} 1200w" sizes="100vw" loading="lazy" alt="{{ $alt }}" {{ with $title }}title="{{ . }}"{{ end }} width="{{ $large.Width }}" height="{{ $large.Height }}">
+  </picture>
+{{- else -}}
+  <img src="{{ .Destination | relURL }}" alt="{{ $alt }}" {{ with $title }}title="{{ . }}"{{ end }} loading="lazy">
+{{- end -}}

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -3,13 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ .Title }} - {{ .Site.Title }}{{ end }}</title>
-  {{ with .Params.description }}
-  <meta name="description" content="{{ . }}">
-  {{ end }}
-  {{ with .Params.keywords }}
-  <meta name="keywords" content="{{ delimit . ", " }}">
-  {{ end }}
+  {{ partial "seo/meta.html" . }}
+  {{ partial "seo/schema.html" . }}
   <link rel="stylesheet" href="{{ "/css/style.css" | relURL }}">
 </head>
 <body>
@@ -29,5 +24,6 @@
   <footer>
     <p>&copy; {{ now.Format "2006" }} {{ .Site.Title }}</p>
   </footer>
+  {{ partial "analytics.html" . }}
 </body>
 </html>

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,6 +1,7 @@
 {{ define "main" }}
+{{ partial "breadcrumbs.html" . }}
 <section>
-  <h2>{{ .Title }}</h2>
+  <h1>{{ .Title }}</h1>
   <ul>
     {{ range .Pages }}
     <li><a href="{{ .RelPermalink }}">{{ .Title }}</a></li>

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,5 +1,16 @@
 {{ define "main" }}
+{{ partial "breadcrumbs.html" . }}
 <article>
   {{ .Content }}
 </article>
+{{ with site.RegularPages.Related . }}
+<section>
+  <h2>Related Content</h2>
+  <ul>
+    {{ range first 5 . }}
+    <li><a href="{{ .RelPermalink }}">{{ .Title }}</a></li>
+    {{ end }}
+  </ul>
+</section>
+{{ end }}
 {{ end }}

--- a/layouts/index.robots.txt
+++ b/layouts/index.robots.txt
@@ -1,0 +1,8 @@
+{{- $env := getenv "HUGO_ENV" | default "production" -}}
+User-agent: *
+{{- if eq $env "production" -}}
+Disallow:
+{{- else -}}
+Disallow: /
+{{- end -}}
+Sitemap: {{ .Site.Params.productionBaseURL | default .Site.BaseURL }}sitemap.xml

--- a/layouts/partials/analytics.html
+++ b/layouts/partials/analytics.html
@@ -1,0 +1,11 @@
+{{- $env := getenv "HUGO_ENV" | default "production" -}}
+{{- $id := .Site.Params.ga_id -}}
+{{- if and $id (eq $env "production") -}}
+<script async src="https://www.googletagmanager.com/gtag/js?id={{ $id }}"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', '{{ $id }}', {'anonymize_ip': true});
+</script>
+{{- end -}}

--- a/layouts/partials/breadcrumbs.html
+++ b/layouts/partials/breadcrumbs.html
@@ -1,0 +1,11 @@
+{{- if not .IsHome -}}
+<nav aria-label="Breadcrumb">
+  <ol>
+    <li><a href="{{ .Site.BaseURL }}">Home</a></li>
+    {{- range .Ancestors.Reverse -}}
+      <li><a href="{{ .Permalink }}">{{ .Title }}</a></li>
+    {{- end -}}
+    <li aria-current="page">{{ .Title }}</li>
+  </ol>
+</nav>
+{{- end -}}

--- a/layouts/partials/seo/meta.html
+++ b/layouts/partials/seo/meta.html
@@ -1,0 +1,53 @@
+{{- $env := getenv "HUGO_ENV" | default "production" -}}
+{{- $prod := .Site.Params.productionBaseURL | default .Site.BaseURL -}}
+{{- $siteTitle := .Site.Title -}}
+{{- $title := .Params.title | default .Title -}}
+{{- if not (in (lower $title) (lower $siteTitle)) -}}
+  {{- $title = printf "%s | %s" $title $siteTitle -}}
+{{- end -}}
+{{- with .Site.Params.titleSuffix -}}
+  {{- $title = printf "%s%s" $title . -}}
+{{- end -}}
+<title>{{ $title }}</title>
+{{- if not .Title }}{{ warnf "Missing title for %s" .RelPermalink }}{{ end -}}
+
+{{- $desc := .Params.meta_desc | default (.Summary | plainify) | default .Site.Params.description -}}
+{{- if not .Params.meta_desc }}{{ warnf "Missing meta_desc for %s" .RelPermalink }}{{ end -}}
+{{- if $desc }}<meta name="description" content="{{ $desc | plainify | htmlEscape }}">{{ end -}}
+
+{{- $robots := "index,follow" -}}
+{{- if .Params.noindex }}{{ $robots = "noindex,follow" }}{{ end -}}
+{{- with .Params.robots }}{{ $robots = . }}{{ end -}}
+<meta name="robots" content="{{ $robots }}">
+
+{{- $canon := .Permalink -}}
+{{- with .Params.canonical }}{{ $canon = . | absURL }}{{ end -}}
+{{- if ne $env "production" }}{{ $canon = replace $canon .Site.BaseURL $prod }}{{ end -}}
+<link rel="canonical" href="{{ $canon }}">
+
+{{- with .OutputFormats.Get "RSS" -}}
+<link rel="alternate" type="application/rss+xml" href="{{ .RelPermalink }}" title="{{ $.Site.Title }}"/>
+{{- end -}}
+
+<meta property="og:type" content="{{ if .IsPage }}article{{ else }}website{{ end }}">
+<meta property="og:title" content="{{ $title }}">
+{{- if $desc }}<meta property="og:description" content="{{ $desc }}">{{ end }}
+<meta property="og:url" content="{{ $canon }}">
+<meta property="og:site_name" content="{{ .Site.Title }}">
+{{- $img := .Params.social_image | default (index .Params.images 0) -}}
+{{- with $img }}<meta property="og:image" content="{{ . | absURL }}">{{ end }}
+
+{{- $card := "summary" -}}
+{{- with $img }}{{ $card = "summary_large_image" }}{{ end -}}
+<meta name="twitter:card" content="{{ $card }}">
+{{- with .Site.Params.social.twitter }}<meta name="twitter:site" content="{{ . }}">{{ end }}
+<meta name="twitter:title" content="{{ $title }}">
+{{- if $desc }}<meta name="twitter:description" content="{{ $desc }}">{{ end }}
+{{- with $img }}<meta name="twitter:image" content="{{ . | absURL }}">{{ end }}
+
+{{- if .IsTranslated -}}
+{{- range .Translations -}}
+<link rel="alternate" hreflang="{{ .Lang }}" href="{{ .Permalink }}" />
+{{- end -}}
+<link rel="alternate" hreflang="x-default" href="{{ .Permalink }}" />
+{{- end -}}

--- a/layouts/partials/seo/schema.html
+++ b/layouts/partials/seo/schema.html
@@ -1,0 +1,44 @@
+{{- $env := getenv "HUGO_ENV" | default "production" -}}
+{{- $base := .Site.Params.productionBaseURL | default .Site.BaseURL -}}
+{{- $schemas := slice -}}
+
+{{- $org := dict "@type" "Organization" "name" .Site.Title "url" $base -}}
+{{- with .Site.Params.logo }}{{ $org = merge $org (dict "logo" (absURL .)) }}{{ end -}}
+{{- $schemas = $schemas | append $org -}}
+
+{{- $website := dict "@type" "WebSite" "name" .Site.Title "url" $base -}}
+{{- with .Site.Params.search.url -}}
+  {{- $website = merge $website (dict "potentialAction" (dict "@type" "SearchAction" "target" (printf "%s?q={search_term_string}" .) "query-input" "required name=search_term_string")) -}}
+{{- end -}}
+{{- $schemas = $schemas | append $website -}}
+
+{{- /* Breadcrumbs */ -}}
+{{- $crumbs := slice -}}
+{{- $pos := 1 -}}
+{{- $section := .CurrentSection -}}
+{{- if $section -}}
+  {{- range (append ($section.Ancestors.Reverse) (slice $section)) -}}
+    {{- $crumbs = $crumbs | append (dict "@type" "ListItem" "position" $pos "name" .Title "item" (replace .Permalink .Site.BaseURL $base)) -}}
+    {{- $pos = add $pos 1 -}}
+  {{- end -}}
+{{- end -}}
+{{- if .IsPage -}}
+  {{- $crumbs = $crumbs | append (dict "@type" "ListItem" "position" $pos "name" .Title "item" (replace .Permalink .Site.BaseURL $base)) -}}
+{{- end -}}
+{{- if gt (len $crumbs) 0 -}}
+  {{- $schemas = $schemas | append (dict "@type" "BreadcrumbList" "itemListElement" $crumbs) -}}
+{{- end -}}
+
+{{- if .IsPage -}}
+  {{- $ptype := "WebPage" -}}
+  {{- if in (slice "posts" "blog") .Section }}{{ $ptype = "Article" }}{{ end -}}
+  {{- $page := dict "@type" $ptype "headline" .Title "url" (replace .Permalink .Site.BaseURL $base) "datePublished" (.PublishDate | time.Format "2006-01-02") "dateModified" (.Lastmod | time.Format "2006-01-02") -}}
+  {{- with .Params.author }}{{ $page = merge $page (dict "author" (dict "@type" "Person" "name" .)) }}{{ end -}}
+  {{- with (or .Params.images (slice)) }}{{ $page = merge $page (dict "image" (apply (first 1 .) "absURL" ".")) }}{{ end -}}
+  {{- with .Params.schema }}{{ $page = merge $page . }}{{ end -}}
+  {{- $schemas = $schemas | append $page -}}
+{{- end -}}
+
+<script type="application/ld+json">
+{{ $schemas | jsonify }}
+</script>


### PR DESCRIPTION
## Summary
- add reusable SEO meta and schema partials with canonical, Open Graph, and JSON-LD
- enable environment-aware robots.txt, analytics, breadcrumbs, and responsive images
- document SEO front-matter contract and add CI workflow for basic QA

## Testing
- `hugo --gc --minify`


------
https://chatgpt.com/codex/tasks/task_e_68be371ee3a48325866213dadab30780