### PR TITLE
Set production and development site URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
 # localpestco
 
 This site is built with [Hugo](https://gohugo.io/) and requires version `0.146.0` or later.
+
+## URLs
+
+- Production: https://localpest.co/
+- Development: https://localpestco.pages.dev/

--- a/hugo.toml
+++ b/hugo.toml
@@ -1,4 +1,4 @@
-baseURL = 'https://www.example.com/'
+baseURL = 'https://localpestco.pages.dev/'
 languageCode = 'en-us'
 title = 'Local Pest Co'
 # theme removed to use custom layouts
@@ -21,7 +21,7 @@ home = ['HTML', 'RSS', 'Robots']
 
 [params]
   # canonical production URL used for canonicals and sitemap
-  productionBaseURL = 'https://www.example.com/'
+  productionBaseURL = 'https://localpest.co/'
   # optional title suffix appended to page titles
   titleSuffix = ''
   # Google Analytics ID (GA4)


### PR DESCRIPTION
## Summary
- set baseURL to development domain
- configure canonical production URL
- document production and development URLs

## Testing
- `hugo --gc --minify`
- `htmltest` *(fails: command not found)*
- `html-validate public/**/*.html` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be3eec92e48325af32b32def7f702c