### PR TITLE
feat: refine headings and meta for accessibility and SEO

### DIFF
--- a/docs/audit.md
+++ b/docs/audit.md
@@ -1,0 +1,37 @@
+# SEO & UX Audit Plan
+
+## Current Issues
+- **Headings**: Site title uses `<h1>` in the header and content pages lack an explicit `<h1>`, leading to multiple or missing top-level headings.
+- **Metadata**: `description` front matter isn't picked up for meta description because the partial expects `meta_desc`.
+- **Last Modified**: `enableGitInfo` disabled; no `<meta property="article:modified_time">`.
+- **Accessibility**: No skip link to main content; navigation has no structural indication of current page.
+- **Performance**: CSS served from `static/` without minification or fingerprinting.
+
+## Planned Changes
+- Update templates to ensure a single `<h1>` per page sourced from front matter.
+- Allow `description` front matter to populate meta description and include `article:modified_time`.
+- Enable `enableGitInfo` in `hugo.toml` for accurate `.Lastmod`.
+- Add a skip-to-content link and main landmark ID for keyboard users; style skip link for focus visibility.
+
+## Requires Approval
+- Migrating CSS/JS to Hugo Pipes for minification and fingerprinting.
+- Adding LocalBusiness schema if business address/phone details are provided in site params.
+- Further navigation or URL structure changes.
+
+## Testing
+- `hugo`
+- `npx linkinator public` (after build)
+
+## Changes Made
+- Enabled Git-based lastmod and added `<meta property="article:modified_time">`.
+- Reworked heading structure: site title no longer `<h1>`; templates now output page titles as `<h1>`.
+- Added skip-to-content link and focusable styles.
+- Meta partial now reads `description` front matter for meta descriptions.
+
+## Test Results
+- `hugo --minify` – warns about missing meta description on the 404 page.
+- `npx linkinator public` – one broken external link (placeholder image returning 503).
+
+## Core Web Vitals Risks
+- [ ] Stylesheet not yet minified or fingerprinted.
+- [ ] Placeholder external images returned errors during link check.

--- a/hugo.toml
+++ b/hugo.toml
@@ -4,6 +4,7 @@ title = 'Local Pest Co'
 # theme removed to use custom layouts
 min_version = '0.146.0'
 disableKinds = ['taxonomy', 'term']
+enableGitInfo = true
 
 [outputs]
 home = ['HTML', 'RSS', 'Robots']

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -8,8 +8,9 @@
   <link rel="stylesheet" href="{{ "/css/style.css" | relURL }}">
 </head>
 <body>
+  <a class="skip-link" href="#main-content">Skip to content</a>
   <header>
-    <h1><a href="{{ "/" | relURL }}">{{ .Site.Title }}</a></h1>
+    <p class="site-title"><a href="{{ "/" | relURL }}">{{ .Site.Title }}</a></p>
     <nav>
       <a href="{{ "/" | relURL }}">Home</a>
       <a href="{{ "/services/" | relURL }}">Services</a>
@@ -18,7 +19,7 @@
       <a href="{{ "/contact/" | relURL }}">Contact</a>
     </nav>
   </header>
-  <main>
+  <main id="main-content">
     {{ block "main" . }}{{ end }}
   </main>
   <footer>

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,6 +1,7 @@
 {{ define "main" }}
 {{ partial "breadcrumbs.html" . }}
 <article>
+  <h1>{{ .Title }}</h1>
   {{ .Content }}
 </article>
 {{ with site.RegularPages.Related . }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,5 +1,6 @@
 {{ define "main" }}
 <section>
+  <h1>{{ .Title }}</h1>
   {{ .Content }}
 </section>
 {{ end }}

--- a/layouts/partials/seo/meta.html
+++ b/layouts/partials/seo/meta.html
@@ -11,8 +11,8 @@
 <title>{{ $title }}</title>
 {{- if not .Title }}{{ warnf "Missing title for %s" .RelPermalink }}{{ end -}}
 
-{{- $desc := .Params.meta_desc | default (.Summary | plainify) | default .Site.Params.description -}}
-{{- if not .Params.meta_desc }}{{ warnf "Missing meta_desc for %s" .RelPermalink }}{{ end -}}
+{{- $desc := .Params.meta_desc | default .Params.description | default (.Summary | plainify) | default .Site.Params.description -}}
+{{- if and (not .Params.meta_desc) (not .Params.description) }}{{ warnf "Missing meta description for %s" .RelPermalink }}{{ end -}}
 {{- if $desc }}<meta name="description" content="{{ $desc | plainify | htmlEscape }}">{{ end -}}
 
 {{- $robots := "index,follow" -}}
@@ -24,6 +24,8 @@
 {{- with .Params.canonical }}{{ $canon = . | absURL }}{{ end -}}
 {{- if ne $env "production" }}{{ $canon = replace $canon .Site.BaseURL $prod }}{{ end -}}
 <link rel="canonical" href="{{ $canon }}">
+
+{{- if .IsPage }}<meta property="article:modified_time" content="{{ .Lastmod.Format "2006-01-02T15:04:05Z07:00" }}">{{ end -}}
 
 {{- with .OutputFormats.Get "RSS" -}}
 <link rel="alternate" type="application/rss+xml" href="{{ .RelPermalink }}" title="{{ $.Site.Title }}"/>

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -15,6 +15,24 @@ nav a {
   color: #333;
 }
 
+.skip-link {
+  position: absolute;
+  left: -999px;
+  top: auto;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+}
+
+.skip-link:focus {
+  position: static;
+  width: auto;
+  height: auto;
+  padding: 1rem;
+  background: #000;
+  color: #fff;
+}
+
 main {
   padding: 1rem;
 }


### PR DESCRIPTION
## Summary
- ensure Git-based `lastmod` and expose `article:modified_time` meta tag
- standardize page headings and add skip-to-content link
- allow `description` front matter for meta descriptions

## Testing
- `hugo --minify`
- `npx linkinator public` *(1 broken external link from placeholder image)*

------
https://chatgpt.com/codex/tasks/task_e_68be45c960a48325828e77e60ac7a035