### PR TITLE
Add Northern Rivers termite control page with NSW licensing links

### DIFF
--- a/content/termite-control-northern-rivers.md
+++ b/content/termite-control-northern-rivers.md
@@ -1,0 +1,25 @@
++++
+title = "Northern Rivers Termite Control Specialists"
+description = "Targeted termite inspections and treatments for homes across the Northern Rivers region."
+keywords = ["Northern Rivers termite control", "termite inspections NSW", "licensed termite treatment"]
++++
+
+## Local Termite Expertise
+
+Termites thrive in the warm, humid conditions of the Northern Rivers. Our technicians focus on early detection and prevention to protect timber homes from costly damage.
+
+## Signs of Termites in Northern Rivers Homes
+
+- Mud tubes along foundations and walls
+- Soft or hollow-sounding timber
+- Discarded wings near windowsills
+
+## NSW Licensing & Regulations
+
+All termite work in New South Wales must be carried out by licensed professionals. Local Pest Co holds the required pest management technician licence issued by the NSW Environment Protection Authority ([EPA NSW](https://www.epa.nsw.gov.au/your-environment/pesticides/licences-and-permits/pest-management-technicians-and-businesses)).
+
+For homeowners, NSW Fair Trading provides guidance on engaging accredited pest controllers and understanding treatment options ([NSW Fair Trading - Pest Management](https://www.fairtrading.nsw.gov.au/housing-and-property/building-and-renovating/pest-management)).
+
+## Book a Northern Rivers Termite Inspection
+
+Schedule a comprehensive termite inspection today to safeguard your Northern Rivers property.


### PR DESCRIPTION
## Summary
- Add dedicated termite control page targeting Northern Rivers homeowners
- Highlight licensing requirements with links to NSW EPA and NSW Fair Trading

## Testing
- `hugo --gc --minify` *(fails: command not found)*
- `htmltest || true` *(fails: command not found)*
- `html-validate public/**/*.html || true` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be4ad02bd88325a2f8e9570892044e