### PR TITLE
Add placeholder banners and scroll animations

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -4,10 +4,12 @@ description = "Eco-friendly Kingscliff pest control for homes and businesses acr
 keywords = ["Kingscliff pest control", "Tweed Coast termite treatment", "rodent removal Kingscliff", "ant exterminator Tweed Heads"]
 +++
 
-![Pest control technician inspecting a Kingscliff home](https://via.placeholder.com/800x400 "Technician treating a Kingscliff home")
+![Pest control technician inspecting a Kingscliff home](https://placehold.co/800x400?text=Inspection "Technician treating a Kingscliff home")
 
 I'm an Aboriginal pest control specialist based in Kingscliff. I offer prompt, eco-conscious solutions for termites, rodents, ants, and other pests for homes and businesses across the Tweed Coast and Northern Rivers.
 
 Whether you're in Kingscliff, Casuarina, or Tweed Heads, I provide local pest control that protects families, pets, and the environment.
 
 Call me on 0405 508 035 or email thelocalpestco@bigpond.com for same or next-day service.
+
+![Placeholder pest control banner](https://placehold.co/1200x300?text=Pest+Control+Services)

--- a/content/about.md
+++ b/content/about.md
@@ -4,7 +4,7 @@ description = "Learn about Local Pest Co, a Kingscliff-based Aboriginal-owned pe
 keywords = ["about Local Pest Co", "Kingscliff pest experts", "Tweed Coast local pest control"]
 +++
 
-![Local Pest Co owner standing beside service vehicle](https://via.placeholder.com/600x300 "Owner beside Local Pest Co truck")
+![Local Pest Co owner standing beside service vehicle](https://placehold.co/600x300?text=Owner "Owner beside Local Pest Co truck")
 
 Founded and operated by me, an Aboriginal local, Local Pest Co combines my community knowledge with licensed pest management techniques for Kingscliff and surrounding suburbs. I focus on safe methods that respect families, pets, and the environment while keeping Tweed Coast homes pest-free.
 

--- a/content/contact.md
+++ b/content/contact.md
@@ -4,7 +4,7 @@ description = "Contact Local Pest Co for Kingscliff and Tweed Coast pest control
 keywords = ["contact pest control Kingscliff", "Tweed Coast pest service phone", "email Local Pest Co"]
 +++
 
-![Map pinpointing Kingscliff and the Tweed Coast service area](https://via.placeholder.com/600x300 "Map of Kingscliff service area")
+![Map pinpointing Kingscliff and the Tweed Coast service area](https://placehold.co/600x300?text=Service+Area "Map of Kingscliff service area")
 
 Phone: 0405 508 035
 

--- a/content/services.md
+++ b/content/services.md
@@ -4,7 +4,7 @@ description = "Comprehensive pest control services for Kingscliff and Tweed Coas
 keywords = ["Kingscliff termite treatment", "Tweed Coast rodent control", "ant and cockroach solutions"]
 +++
 
-![Technician applying eco-friendly pest spray around a Tweed Coast home](https://via.placeholder.com/700x350 "Pest treatment at a Tweed Coast property")
+![Technician applying eco-friendly pest spray around a Tweed Coast home](https://placehold.co/700x350?text=Service "Pest treatment at a Tweed Coast property")
 
 I handle common pest issues with targeted treatments across Kingscliff, Casuarina, Cabarita Beach, and the wider Tweed Coast:
 
@@ -16,3 +16,5 @@ I handle common pest issues with targeted treatments across Kingscliff, Casuarin
 Every visit includes practical advice for prevention and long-term pest management.
 
 Call me on 0405 508 035 or email thelocalpestco@bigpond.com to book a service.
+
+![Placeholder of additional service](https://placehold.co/1000x300?text=More+Services)

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -19,6 +19,7 @@
       <a href="{{ "/contact/" | relURL }}">Contact</a>
     </nav>
   </header>
+  {{ partial "banner.html" . }}
   <main id="main-content">
     {{ block "main" . }}{{ end }}
   </main>
@@ -27,5 +28,6 @@
     <p>&copy; {{ now.Format "2006" }} {{ .Site.Title }}</p>
   </footer>
   {{ partial "analytics.html" . }}
+  <script src="{{ "/js/main.js" | relURL }}"></script>
 </body>
 </html>

--- a/layouts/partials/banner.html
+++ b/layouts/partials/banner.html
@@ -1,0 +1,3 @@
+<div class="banner fade-in-element">
+  <img src="https://placehold.co/1600x400?text=Local+Pest+Co" alt="Local Pest Co banner">
+</div>

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -4,9 +4,20 @@ body {
   padding: 0;
 }
 
+img {
+  max-width: 100%;
+  height: auto;
+  display: block;
+}
+
 header, footer {
   background-color: #f0f0f0;
   padding: 1rem;
+}
+
+header nav {
+  display: flex;
+  flex-wrap: wrap;
 }
 
 nav a {
@@ -51,4 +62,28 @@ main {
   width: 100%;
   height: 200px;
   background-color: #eee;
+}
+
+.banner img {
+  width: 100%;
+  height: auto;
+  display: block;
+}
+
+.fade-in-element {
+  opacity: 0;
+  transform: translateY(20px);
+  transition: opacity 0.6s ease-out, transform 0.6s ease-out;
+}
+
+.fade-in-element.visible {
+  opacity: 1;
+  transform: none;
+}
+
+@media (max-width: 600px) {
+  nav a {
+    display: block;
+    margin: 0.5rem 0;
+  }
 }

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -1,0 +1,19 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const elements = document.querySelectorAll('p, h1, h2, h3, img, .fade-in-element');
+  elements.forEach(el => {
+    el.classList.add('fade-in-element');
+  });
+
+  const observer = new IntersectionObserver(entries => {
+    entries.forEach(entry => {
+      if (entry.isIntersecting) {
+        entry.target.classList.add('visible');
+        observer.unobserve(entry.target);
+      }
+    });
+  }, { threshold: 0.1 });
+
+  document.querySelectorAll('.fade-in-element').forEach(el => {
+    observer.observe(el);
+  });
+});


### PR DESCRIPTION
## Summary
- Add reusable placeholder banner partial using placehold.co
- Introduce scroll-triggered fade-in animation and responsive navigation styling
- Replace images with placehold.co placeholders and add extra banner imagery

## Testing
- `hugo -d /tmp/hugo_build`

------
https://chatgpt.com/codex/tasks/task_e_68be4d5d5e9883258431eefc45a6253f