### PR TITLE
style: improve two-column UI for list pages

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,11 +1,15 @@
 {{ define "main" }}
 {{ partial "breadcrumbs.html" . }}
-<section>
+<section class="page-list">
   <h1>{{ .Title }}</h1>
-  <ul>
-    {{ range .Pages }}
-    <li><a href="{{ .RelPermalink }}">{{ .Title }}</a></li>
-    {{ end }}
-  </ul>
+  {{ range .Pages }}
+  <article class="content-row">
+    <img src="{{ with .Params.image }}{{ . }}{{ else }}https://placehold.co/400x300{{ end }}" alt="{{ .Title }}" loading="lazy">
+    <div class="text">
+      <h2><a href="{{ .RelPermalink }}">{{ .Title }}</a></h2>
+      {{ with .Params.description }}<p>{{ . }}</p>{{ end }}
+    </div>
+  </article>
+  {{ end }}
 </section>
 {{ end }}

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -54,6 +54,8 @@ nav a {
 
 main {
   padding: 1rem;
+  max-width: 1000px;
+  margin: 0 auto;
 }
 
 .hero {
@@ -89,9 +91,39 @@ main {
   transform: none;
 }
 
+.page-list {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.content-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: center;
+  padding: 1rem;
+  background: #f9f9f9;
+  border-radius: 8px;
+}
+
+.content-row img {
+  flex: 1 1 200px;
+  max-width: 300px;
+  border-radius: 4px;
+}
+
+.content-row .text {
+  flex: 2 1 300px;
+}
+
 @media (max-width: 600px) {
   nav a {
     display: block;
     margin: 0.5rem 0;
+  }
+
+  .content-row {
+    flex-direction: column;
   }
 }


### PR DESCRIPTION
## Summary
- add responsive two-column list layout with padded rows and image/text pairing
- center main content area for better readability

## Testing
- `hugo --minify`

------
https://chatgpt.com/codex/tasks/task_e_68be52ebbf8c832587111a69a871442a