### PR TITLE
feat: apply warm color theme

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1,7 +1,16 @@
+:root {
+  --color-dark-bg: #D6CEC2;
+  --color-light-bg: #F6F4EE;
+  --color-accent-red: #B81010;
+  --color-black: #070807;
+}
+
 body {
   font-family: Arial, sans-serif;
   margin: 0;
   padding: 0;
+  background-color: var(--color-light-bg);
+  color: var(--color-black);
 }
 
 img {
@@ -11,7 +20,7 @@ img {
 }
 
 header {
-  background-color: #f0f0f0;
+  background-color: var(--color-dark-bg);
   padding: 1rem;
   position: sticky;
   top: 0;
@@ -51,14 +60,17 @@ header .main-nav {
 }
 
 footer {
-  background-color: #f0f0f0;
+  background-color: var(--color-dark-bg);
   padding: 1rem;
 }
 
 nav a {
   margin-right: 1rem;
   text-decoration: none;
-  color: #333;
+  color: var(--color-black);
+}
+nav a:hover {
+  color: var(--color-accent-red);
 }
 
 .skip-link {
@@ -75,8 +87,8 @@ nav a {
   width: auto;
   height: auto;
   padding: 1rem;
-  background: #000;
-  color: #fff;
+  background: var(--color-black);
+  color: var(--color-light-bg);
 }
 
 main {
@@ -96,17 +108,17 @@ main {
 .hero {
   width: 100%;
   height: 250px;
-  background-color: #ddd;
+  background-color: var(--color-dark-bg);
   display: flex;
   align-items: center;
   justify-content: center;
-  color: #666;
+  color: var(--color-black);
 }
 
 .placeholder-box {
   width: 100%;
   height: 200px;
-  background-color: #eee;
+  background-color: var(--color-light-bg);
 }
 
 .banner img {
@@ -138,8 +150,12 @@ main {
   gap: 1rem;
   align-items: center;
   padding: 1rem;
-  background: #f9f9f9;
+  background: var(--color-light-bg);
   border-radius: 8px;
+}
+
+.phone-link {
+  color: var(--color-accent-red);
 }
 
 .content-row img {


### PR DESCRIPTION
## Summary
- establish CSS variables for a warm palette and default text color
- apply new theme to global layout, navigation, and content sections
- add accent red to navigation hover and phone link

## Testing
- `hugo -d /tmp/hugo-build`


------
https://chatgpt.com/codex/tasks/task_e_68be572f8a1883258005fc11111e9083