### PR TITLE
Add welcome splash screen

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -8,6 +8,10 @@
   <link rel="stylesheet" href="{{ "/css/style.css" | relURL }}">
 </head>
 <body>
+  <div id="splash-screen" aria-hidden="true">
+    <div class="message aboriginal">Jingi Walla</div>
+    <div class="message english">Welcome</div>
+  </div>
   <a class="skip-link" href="#main-content">Skip to content</a>
   <header>
     <p class="site-title"><a href="{{ "/" | relURL }}">{{ .Site.Title }}</a></p>

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -240,3 +240,43 @@ main {
     flex-direction: column;
   }
 }
+
+#splash-screen {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: var(--color-light-bg);
+  color: var(--color-black);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  z-index: 2000;
+  transition: opacity 1s ease;
+}
+
+#splash-screen .message {
+  position: absolute;
+  font-size: 2rem;
+  font-weight: bold;
+  transition: opacity 1s ease;
+}
+
+#splash-screen .english {
+  opacity: 0;
+}
+
+#splash-screen.fade-english .aboriginal {
+  opacity: 0;
+}
+
+#splash-screen.fade-english .english {
+  opacity: 1;
+}
+
+#splash-screen.hide {
+  opacity: 0;
+  visibility: hidden;
+}

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -53,4 +53,19 @@ document.addEventListener('DOMContentLoaded', () => {
       }
     });
   });
+
+  const splash = document.getElementById('splash-screen');
+  if (splash) {
+    window.addEventListener('load', () => {
+      setTimeout(() => {
+        splash.classList.add('fade-english');
+      }, 1000);
+      setTimeout(() => {
+        splash.classList.add('hide');
+      }, 2000);
+      setTimeout(() => {
+        splash.remove();
+      }, 3000);
+    });
+  }
 });


### PR DESCRIPTION
## Summary
- Introduce a splash screen that greets visitors with "Jingi Walla" and then fades to "Welcome" before showing the site.
- Add CSS for full-screen overlay and fade transitions.
- Add JavaScript to sequence the message fades and remove the splash once the page loads.

## Testing
- `hugo`


------
https://chatgpt.com/codex/tasks/task_e_68be5bba41648325b1413adafbd57d12