### PR TITLE
Show splash screen only on first visit

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -6,6 +6,11 @@
   {{ partial "seo/meta.html" . }}
   {{ partial "seo/schema.html" . }}
   <link rel="stylesheet" href="{{ "/css/style.css" | relURL }}">
+  <script>
+    if (document.cookie.split(';').some(c => c.trim() === 'splashSeen=true')) {
+      document.documentElement.classList.add('seen-splash');
+    }
+  </script>
 </head>
 <body>
   <div id="splash-screen" aria-hidden="true">

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -254,14 +254,18 @@ main {
   justify-content: center;
   overflow: hidden;
   z-index: 2000;
-  transition: opacity 1s ease;
+  transition: opacity 2s ease;
+}
+
+.seen-splash #splash-screen {
+  display: none;
 }
 
 #splash-screen .message {
   position: absolute;
   font-size: 2rem;
   font-weight: bold;
-  transition: opacity 1s ease;
+  transition: opacity 2s ease;
 }
 
 #splash-screen .english {

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -56,16 +56,22 @@ document.addEventListener('DOMContentLoaded', () => {
 
   const splash = document.getElementById('splash-screen');
   if (splash) {
-    window.addEventListener('load', () => {
-      setTimeout(() => {
-        splash.classList.add('fade-english');
-      }, 1000);
-      setTimeout(() => {
-        splash.classList.add('hide');
-      }, 2000);
-      setTimeout(() => {
-        splash.remove();
-      }, 3000);
-    });
+    const hasSeenSplash = document.cookie.split(';').some(c => c.trim() === 'splashSeen=true');
+    if (hasSeenSplash) {
+      splash.remove();
+    } else {
+      window.addEventListener('load', () => {
+        document.cookie = 'splashSeen=true; path=/; max-age=31536000';
+        setTimeout(() => {
+          splash.classList.add('fade-english');
+        }, 1000);
+        setTimeout(() => {
+          splash.classList.add('hide');
+        }, 3000);
+        setTimeout(() => {
+          splash.remove();
+        }, 5000);
+      });
+    }
   }
 });


### PR DESCRIPTION
## Summary
- Use cookie to track splash screen visibility across visits
- Add inline script to skip splash when cookie exists and slow down fade animation

## Testing
- `hugo`

------
https://chatgpt.com/codex/tasks/task_e_68be5d3186288325a04e8c9bcbc2a35c