### PR TITLE
Improve header navigation spacing and logo layout

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -19,7 +19,7 @@
   </div>
   <a class="skip-link" href="#main-content">Skip to content</a>
   <header>
-    <p class="site-title"><a href="{{ "/" | relURL }}">{{ .Site.Title }}</a></p>
+    <div class="logo"><a href="{{ "/" | relURL }}"><img src="{{ "/images/logo-placeholder.svg" | relURL }}" alt="{{ .Site.Title }} logo"></a></div>
     <nav class="main-nav">
       <ul>
         <li><a href="{{ "/" | relURL }}">Home</a></li>

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -27,6 +27,7 @@ header {
   z-index: 1000;
   display: flex;
   align-items: center;
+  gap: 1rem;
 }
 
 header .main-nav ul {
@@ -35,11 +36,12 @@ header .main-nav ul {
   margin: 0;
   padding: 0;
   list-style: none;
+  gap: 1rem;
 }
 
 header .main-nav li {
   position: relative;
-  margin-right: 1rem;
+  margin: 0;
 }
 
 .header-actions {
@@ -47,6 +49,12 @@ header .main-nav li {
   display: flex;
   align-items: center;
   gap: 0.5rem;
+}
+
+.logo img {
+  width: 50px;
+  height: 50px;
+  border-radius: 50%;
 }
 
 .menu-toggle,
@@ -74,6 +82,7 @@ footer {
 nav a {
   text-decoration: none;
   color: var(--color-black);
+  transition: color 0.3s ease;
 }
 nav a:hover {
   color: var(--color-accent-red);
@@ -222,6 +231,7 @@ main {
     margin: 0;
     display: none;
     flex-direction: column;
+    gap: 0;
   }
 
   header .main-nav.open ul {

--- a/static/images/logo-placeholder.svg
+++ b/static/images/logo-placeholder.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="80" height="80" viewBox="0 0 80 80">
+  <circle cx="40" cy="40" r="40" fill="#ddd" />
+</svg>


### PR DESCRIPTION
## Summary
- Replace text site title with circular logo placeholder
- Space out header navigation and add smoother hover transitions
- Add basic styling for image logo

## Testing
- `hugo --minify`


------
https://chatgpt.com/codex/tasks/task_e_68be5e8149308325a644890e981c5f84