### PR TITLE
Fix header scroll flicker with distinct activation thresholds

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -77,10 +77,13 @@ document.addEventListener('DOMContentLoaded', () => {
 
   const header = document.querySelector('header');
   if (header) {
+    const activateAt = 60;
+    const deactivateAt = 40;
     const handleScroll = () => {
-      if (window.scrollY > 50) {
+      const { scrollY } = window;
+      if (scrollY > activateAt) {
         header.classList.add('scrolled');
-      } else {
+      } else if (scrollY < deactivateAt) {
         header.classList.remove('scrolled');
       }
     };


### PR DESCRIPTION
## Summary
- add separate scroll thresholds to manage header `scrolled` class
- prevent rapid toggling when near transition point

## Testing
- `hugo`

------
https://chatgpt.com/codex/tasks/task_e_68be6173ed648325994e1f895354d07a