### PR TITLE
Fix nav shrink scroll bug

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -77,13 +77,12 @@ document.addEventListener('DOMContentLoaded', () => {
 
   const header = document.querySelector('header');
   if (header) {
-    const activateAt = 60;
-    const deactivateAt = 40;
+    const activateAt = 300;
     const handleScroll = () => {
       const { scrollY } = window;
       if (scrollY > activateAt) {
         header.classList.add('scrolled');
-      } else if (scrollY < deactivateAt) {
+      } else if (scrollY <= 0) {
         header.classList.remove('scrolled');
       }
     };


### PR DESCRIPTION
## Summary
- shrink header only after scrolling 300px
- restore full header only when back at top to stop scroll bounce

## Testing
- `hugo`


------
https://chatgpt.com/codex/tasks/task_e_68be6356b6d08325a655cfe750c1b49a