### PR TITLE
feat: create full-screen mobile menu

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -54,8 +54,37 @@
         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5"/></svg>
       </button>
     </div>
-  </header>
-  {{ partial "banner.html" . }}
+    </header>
+    <nav class="mobile-nav" aria-label="Mobile navigation" aria-hidden="true">
+      <button class="close-menu" aria-label="Close navigation">
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/></svg>
+      </button>
+      <ul>
+        <li><a href="{{ "/" | relURL }}">Home</a></li>
+        <li class="dropdown">
+          <a href="{{ "/services/" | relURL }}">Services</a>
+          <ul class="dropdown-menu">
+            <li><a href="{{ "/eco-friendly-pest-control/" | relURL }}">Eco-Friendly Pest Control</a></li>
+            <li><a href="{{ "/termite-control-northern-rivers/" | relURL }}">Termite Control</a></li>
+          </ul>
+        </li>
+        <li class="dropdown">
+          <a href="{{ "/locations/" | relURL }}">Locations</a>
+          <ul class="dropdown-menu">
+            <li><a href="{{ "/locations/cabarita-beach/" | relURL }}">Cabarita Beach</a></li>
+            <li><a href="{{ "/locations/casuarina/" | relURL }}">Casuarina</a></li>
+            <li><a href="{{ "/locations/chinderah/" | relURL }}">Chinderah</a></li>
+            <li><a href="{{ "/locations/cudgen/" | relURL }}">Cudgen</a></li>
+            <li><a href="{{ "/locations/fingal-head/" | relURL }}">Fingal Head</a></li>
+            <li><a href="{{ "/locations/kingscliff/" | relURL }}">Kingscliff</a></li>
+            <li><a href="{{ "/locations/pottsville/" | relURL }}">Pottsville</a></li>
+          </ul>
+        </li>
+        <li><a href="{{ "/about/" | relURL }}">About</a></li>
+        <li><a href="{{ "/contact/" | relURL }}">Contact</a></li>
+      </ul>
+    </nav>
+    {{ partial "banner.html" . }}
   {{ partial "cta.html" . }}
   <main id="main-content">
     {{ block "main" . }}{{ end }}

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -90,6 +90,35 @@ header.scrolled .logo img {
   height: 24px;
 }
 
+.mobile-nav {
+  display: none;
+}
+
+.mobile-nav ul {
+  list-style: none;
+  margin: 0;
+  padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.mobile-nav .close-menu {
+  align-self: flex-end;
+  background: none;
+  border: none;
+  cursor: pointer;
+}
+
+.mobile-nav .close-menu svg {
+  width: 24px;
+  height: 24px;
+}
+
+.mobile-nav .dropdown-menu {
+  padding-left: 1rem;
+}
+
 footer {
   background-color: var(--color-dark-bg);
   padding: 1rem;
@@ -247,20 +276,17 @@ main {
     flex-wrap: wrap;
   }
 
-  header .main-nav ul {
-    width: 100%;
-    margin: 0;
+  .main-nav {
     display: none;
-    flex-direction: column;
-    gap: 0;
   }
 
-  header .main-nav.open ul {
+  .mobile-nav.open {
     display: flex;
-  }
-
-  header .main-nav li {
-    margin-right: 0;
+    position: fixed;
+    inset: 0;
+    background: var(--color-light-bg);
+    z-index: 2000;
+    flex-direction: column;
   }
 
   .menu-toggle {

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -18,10 +18,16 @@ document.addEventListener('DOMContentLoaded', () => {
   });
 
   const menuToggle = document.querySelector('.menu-toggle');
-  const mainNav = document.querySelector('.main-nav');
-  if (menuToggle && mainNav) {
+  const mobileNav = document.querySelector('.mobile-nav');
+  const closeMenu = document.querySelector('.close-menu');
+  if (menuToggle && mobileNav) {
     menuToggle.addEventListener('click', () => {
-      mainNav.classList.toggle('open');
+      mobileNav.classList.toggle('open');
+    });
+  }
+  if (closeMenu && mobileNav) {
+    closeMenu.addEventListener('click', () => {
+      mobileNav.classList.remove('open');
     });
   }
 


### PR DESCRIPTION
## Summary
- add dedicated mobile navigation overlay
- style mobile menu to cover entire screen
- update scripts to toggle mobile menu open/closed

## Testing
- `hugo`


------
https://chatgpt.com/codex/tasks/task_e_68be6a10208083258e66222b868323ba