### PR TITLE
Add image request list and shortcode with placeholder fallback

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -12,7 +12,7 @@ question = "Do you offer same-day pest control?"
 answer = "Yes, I provide same or next-day service whenever possible."
 +++
 
-![Pest control technician inspecting a Kingscliff home](https://placehold.co/800x400?text=Inspection "Technician treating a Kingscliff home")
+{{< requestedimg file="home-1.jpg" alt="Pest control technician inspecting a Kingscliff home" >}}
 
 I'm an Aboriginal pest control specialist based in Kingscliff. I offer prompt, eco-conscious solutions for termites, rodents, ants, and other pests for homes and businesses across the Tweed Coast and Northern Rivers.
 
@@ -20,4 +20,4 @@ Whether you're in Kingscliff, Casuarina, or Tweed Heads, I provide local pest co
 
 Call me on 0405 508 035 or email thelocalpestco@bigpond.com for same or next-day service.
 
-![Placeholder pest control banner](https://placehold.co/1200x300?text=Pest+Control+Services)
+{{< requestedimg file="home-2.jpg" alt="Banner promoting Local Pest Co pest control services" >}}

--- a/content/about.md
+++ b/content/about.md
@@ -12,7 +12,7 @@ question = "Do you guarantee your work?"
 answer = "All treatments include practical follow-up advice and a service guarantee."
 +++
 
-![Local Pest Co owner standing beside service vehicle](https://placehold.co/600x300?text=Owner "Owner beside Local Pest Co truck")
+{{< requestedimg file="about-1.jpg" alt="Local Pest Co owner standing beside a branded service vehicle in Kingscliff" >}}
 
 Founded and operated by me, an Aboriginal local, Local Pest Co combines my community knowledge with licensed pest management techniques for Kingscliff and surrounding suburbs. I focus on safe methods that respect families, pets, and the environment while keeping Tweed Coast homes pest-free.
 

--- a/content/contact.md
+++ b/content/contact.md
@@ -12,7 +12,7 @@ question = "Can I get a quote over the phone?"
 answer = "Yes, I'm happy to provide estimates over the phone or via email."
 +++
 
-![Map pinpointing Kingscliff and the Tweed Coast service area](https://placehold.co/600x300?text=Service+Area "Map of Kingscliff service area")
+{{< requestedimg file="contact-1.jpg" alt="Map showing Kingscliff and the broader Tweed Coast service area" >}}
 
 Phone: 0405 508 035
 

--- a/content/locations/cabarita-beach.md
+++ b/content/locations/cabarita-beach.md
@@ -11,11 +11,11 @@ question = "What pests are common in Cabarita Beach?"
 answer = "Termites, ants and rodents are regularly treated in Cabarita Beach homes."
 +++
 
-<div class="hero">Cabarita Beach hero placeholder</div>
+{{< requestedimg file="locations-cabarita-beach-hero.jpg" alt="Cabarita Beach shoreline and headland" >}}
 
 I handle termites, rodents, and other pests for Cabarita Beach properties.
 
-<div class="placeholder-box"></div>
+{{< requestedimg file="locations-cabarita-beach-detail.jpg" alt="Close-up of pests or environments around Cabarita Beach" >}}
 
 ## Why Pest Control is Needed in Cabarita Beach
 

--- a/content/locations/casuarina.md
+++ b/content/locations/casuarina.md
@@ -11,11 +11,11 @@ question = "What pests are common in Casuarina?"
 answer = "Termites, ants and spiders are frequently treated in Casuarina properties."
 +++
 
-<div class="hero">Casuarina hero placeholder</div>
+{{< requestedimg file="locations-casuarina-hero.jpg" alt="Casuarina's coastal suburb streets and homes" >}}
 
 I protect Casuarina homes and businesses with safe, effective pest treatments.
 
-<div class="placeholder-box"></div>
+{{< requestedimg file="locations-casuarina-detail.jpg" alt="Close-up of pests common in Casuarina residences" >}}
 
 ## Why Pest Control is Needed in Casuarina
 

--- a/content/locations/chinderah.md
+++ b/content/locations/chinderah.md
@@ -12,11 +12,11 @@ question = "What pests are common in Chinderah?"
 answer = "Termites and mosquitoes are frequent concerns around Chinderah."
 +++
 
-<div class="hero">Chinderah hero placeholder</div>
+{{< requestedimg file="locations-chinderah-hero.jpg" alt="Aerial view of Chinderah's riverside community on the Tweed Coast" >}}
 
 I provide eco-friendly termite, rodent, ant, spider, and cockroach treatments for homes and businesses across Chinderah.
 
-<div class="placeholder-box"></div>
+{{< requestedimg file="locations-chinderah-detail.jpg" alt="Close-up of common pests found in Chinderah homes" >}}
 
 ## Why Pest Control is Needed in Chinderah
 

--- a/content/locations/cudgen.md
+++ b/content/locations/cudgen.md
@@ -12,11 +12,11 @@ question = "What pests are common in Cudgen?"
 answer = "Rodents, cockroaches and termites are commonly treated in Cudgen."
 +++
 
-<div class="hero">Cudgen hero placeholder</div>
+{{< requestedimg file="locations-cudgen-hero.jpg" alt="Scenic view of Cudgen's rural landscape and homes" >}}
 
 I offer Cudgen residents safe treatments for termites, rodents, cockroaches, ants, and spiders.
 
-<div class="placeholder-box"></div>
+{{< requestedimg file="locations-cudgen-detail.jpg" alt="Close-up of pests typically found in Cudgen properties" >}}
 
 ## Why Pest Control is Needed in Cudgen
 

--- a/content/locations/fingal-head.md
+++ b/content/locations/fingal-head.md
@@ -11,11 +11,11 @@ question = "What pests are common in Fingal Head?"
 answer = "Termites and ants are regular problems in Fingal Head's subtropical climate."
 +++
 
-<div class="hero">Fingal Head hero placeholder</div>
+{{< requestedimg file="locations-fingal-head-hero.jpg" alt="Coastal view of Fingal Head and its lighthouse" >}}
 
 I help Fingal Head residents stay pest-free year round.
 
-<div class="placeholder-box"></div>
+{{< requestedimg file="locations-fingal-head-detail.jpg" alt="Close-up of common pests around Fingal Head properties" >}}
 
 ## Why Pest Control is Needed in Fingal Head
 

--- a/content/locations/kingscliff.md
+++ b/content/locations/kingscliff.md
@@ -12,11 +12,11 @@ question = "What pests are common in Kingscliff?"
 answer = "Termites, cockroaches and rodents are typical in Kingscliff's coastal climate."
 +++
 
-<div class="hero">Kingscliff hero placeholder</div>
+{{< requestedimg file="locations-kingscliff-hero.jpg" alt="Kingscliff coastline with local homes and businesses" >}}
 
 I deliver eco-friendly pest control for homes and businesses in Kingscliff. I handle termites, rodents, ants, spiders, and cockroaches with local expertise.
 
-<div class="placeholder-box"></div>
+{{< requestedimg file="locations-kingscliff-detail.jpg" alt="Close-up of typical pests found in Kingscliff properties" >}}
 
 ## Why Pest Control is Needed in Kingscliff
 

--- a/content/locations/pottsville.md
+++ b/content/locations/pottsville.md
@@ -12,11 +12,11 @@ question = "What pests are common in Pottsville?"
 answer = "Termites and cockroaches are frequent in Pottsville's warm, coastal environment."
 +++
 
-<div class="hero">Pottsville hero placeholder</div>
+{{< requestedimg file="locations-pottsville-hero.jpg" alt="Beachfront scene or town centre view of Pottsville" >}}
 
 From Pottsville to Pottsville Beach, I deliver termite, rodent, ant, spider, and cockroach control with minimal environmental impact.
 
-<div class="placeholder-box"></div>
+{{< requestedimg file="locations-pottsville-detail.jpg" alt="Close-up of pests commonly found in Pottsville homes" >}}
 
 ## Why Pest Control is Needed in Pottsville
 

--- a/content/services.md
+++ b/content/services.md
@@ -12,7 +12,7 @@ question = "Do you provide same-day service?"
 answer = "Yes, I strive to offer same-day or next-day visits across the Tweed Coast."
 +++
 
-![Technician applying eco-friendly pest spray around a Tweed Coast home](https://placehold.co/700x350?text=Service "Pest treatment at a Tweed Coast property")
+{{< requestedimg file="services-1.jpg" alt="Technician applying eco-friendly pest spray around a Tweed Coast home" >}}
 
 I handle common pest issues with targeted treatments across Kingscliff, Casuarina, Cabarita Beach, and the wider Tweed Coast:
 
@@ -25,4 +25,4 @@ Every visit includes practical advice for prevention and long-term pest manageme
 
 Call me on 0405 508 035 or email thelocalpestco@bigpond.com to book a service.
 
-![Placeholder of additional service](https://placehold.co/1000x300?text=More+Services)
+{{< requestedimg file="services-2.jpg" alt="Banner highlighting additional pest control services" >}}

--- a/layouts/shortcodes/requestedimg.html
+++ b/layouts/shortcodes/requestedimg.html
@@ -1,0 +1,3 @@
+{{- $file := .Get "file" -}}
+{{- $alt := .Get "alt" -}}
+<img src="/image-requests/{{ $file }}" alt="{{ $alt }}" loading="lazy" onerror="this.onerror=null;this.src='https://placehold.co/600x300?text=Image+Coming+Soon';" />

--- a/scripts/generate_image_list.py
+++ b/scripts/generate_image_list.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Scan content files for placeholder images and produce a list of required images.
+
+The script searches Markdown files for image references and location placeholders,
+then writes a consolidated list of desired image filenames with improved descriptions.
+"""
+import os
+import re
+from pathlib import Path
+
+CONTENT_DIR = Path('content')
+OUTPUT_DIR = Path('static/image-requests')
+OUTPUT_FILE = OUTPUT_DIR / 'images-needed.txt'
+
+IMAGE_PATTERN = re.compile(r'!\[(.*?)\]\((.*?)\)')
+HERO_PATTERN = re.compile(r'<div class="hero">(.*?) hero placeholder</div>')
+SHORTCODE_PATTERN = re.compile(r'{{<\s*requestedimg\s+file="([^"]+)"\s+alt="([^"]+)"\s*>}}')
+
+
+def slug_from_path(path: Path) -> str:
+    rel = path.relative_to(CONTENT_DIR).with_suffix('')
+    parts = rel.parts
+    if parts and parts[-1] == '_index':
+        parts = parts[:-1] + ('home',)
+    return '-'.join(parts)
+
+
+def improve_description(text: str) -> str:
+    return f"{text}. High-resolution, well-lit photo capturing the subject clearly to convey professionalism and trust."
+
+
+def main() -> None:
+    entries = {}
+    for md_file in CONTENT_DIR.rglob('*.md'):
+        slug = slug_from_path(md_file)
+        content = md_file.read_text(encoding='utf-8')
+
+        index = 1
+        for alt, src in IMAGE_PATTERN.findall(content):
+            if 'placehold' in src:
+                filename = f"{slug}-{index}.jpg"
+                description = improve_description(alt)
+                entries[filename] = description
+                index += 1
+
+        for _ in HERO_PATTERN.findall(content):
+            filename = f"{slug}-hero.jpg"
+            description = improve_description(f"Hero image for {slug.replace('-', ' ')} page")
+            entries[filename] = description
+
+        if '<div class="placeholder-box"></div>' in content:
+            filename = f"{slug}-detail.jpg"
+            description = improve_description(f"Detail image for {slug.replace('-', ' ')} page")
+            entries[filename] = description
+
+        for file_name, alt in SHORTCODE_PATTERN.findall(content):
+            description = improve_description(alt)
+            entries[file_name] = description
+
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+    with OUTPUT_FILE.open('w', encoding='utf-8') as f:
+        for filename in sorted(entries):
+            f.write(f"{filename} | {entries[filename]}\n")
+
+
+if __name__ == '__main__':
+    main()

--- a/static/image-requests/images-needed.txt
+++ b/static/image-requests/images-needed.txt
@@ -1,0 +1,20 @@
+about-1.jpg | Local Pest Co owner standing beside a branded service vehicle in Kingscliff. High-resolution, well-lit photo capturing the subject clearly to convey professionalism and trust.
+contact-1.jpg | Map showing Kingscliff and the broader Tweed Coast service area. High-resolution, well-lit photo capturing the subject clearly to convey professionalism and trust.
+home-1.jpg | Pest control technician inspecting a Kingscliff home. High-resolution, well-lit photo capturing the subject clearly to convey professionalism and trust.
+home-2.jpg | Banner promoting Local Pest Co pest control services. High-resolution, well-lit photo capturing the subject clearly to convey professionalism and trust.
+locations-cabarita-beach-detail.jpg | Close-up of pests or environments around Cabarita Beach. High-resolution, well-lit photo capturing the subject clearly to convey professionalism and trust.
+locations-cabarita-beach-hero.jpg | Cabarita Beach shoreline and headland. High-resolution, well-lit photo capturing the subject clearly to convey professionalism and trust.
+locations-casuarina-detail.jpg | Close-up of pests common in Casuarina residences. High-resolution, well-lit photo capturing the subject clearly to convey professionalism and trust.
+locations-casuarina-hero.jpg | Casuarina's coastal suburb streets and homes. High-resolution, well-lit photo capturing the subject clearly to convey professionalism and trust.
+locations-chinderah-detail.jpg | Close-up of common pests found in Chinderah homes. High-resolution, well-lit photo capturing the subject clearly to convey professionalism and trust.
+locations-chinderah-hero.jpg | Aerial view of Chinderah's riverside community on the Tweed Coast. High-resolution, well-lit photo capturing the subject clearly to convey professionalism and trust.
+locations-cudgen-detail.jpg | Close-up of pests typically found in Cudgen properties. High-resolution, well-lit photo capturing the subject clearly to convey professionalism and trust.
+locations-cudgen-hero.jpg | Scenic view of Cudgen's rural landscape and homes. High-resolution, well-lit photo capturing the subject clearly to convey professionalism and trust.
+locations-fingal-head-detail.jpg | Close-up of common pests around Fingal Head properties. High-resolution, well-lit photo capturing the subject clearly to convey professionalism and trust.
+locations-fingal-head-hero.jpg | Coastal view of Fingal Head and its lighthouse. High-resolution, well-lit photo capturing the subject clearly to convey professionalism and trust.
+locations-kingscliff-detail.jpg | Close-up of typical pests found in Kingscliff properties. High-resolution, well-lit photo capturing the subject clearly to convey professionalism and trust.
+locations-kingscliff-hero.jpg | Kingscliff coastline with local homes and businesses. High-resolution, well-lit photo capturing the subject clearly to convey professionalism and trust.
+locations-pottsville-detail.jpg | Close-up of pests commonly found in Pottsville homes. High-resolution, well-lit photo capturing the subject clearly to convey professionalism and trust.
+locations-pottsville-hero.jpg | Beachfront scene or town centre view of Pottsville. High-resolution, well-lit photo capturing the subject clearly to convey professionalism and trust.
+services-1.jpg | Technician applying eco-friendly pest spray around a Tweed Coast home. High-resolution, well-lit photo capturing the subject clearly to convey professionalism and trust.
+services-2.jpg | Banner highlighting additional pest control services. High-resolution, well-lit photo capturing the subject clearly to convey professionalism and trust.


### PR DESCRIPTION
## Summary
- add `requestedimg` shortcode that loads images from `image-requests/` with placeholder fallback and lazy loading
- introduce `generate_image_list.py` to compile missing image list with detailed descriptions
- replace placeholder images across pages and generate `images-needed.txt`

## Testing
- `python scripts/generate_image_list.py`
- `hugo`

------
https://chatgpt.com/codex/tasks/task_e_68be6b8e562c8325bf32e3867ce6b751