### PR TITLE
Add location-aware SEO suffix to image alt text

### DIFF
--- a/layouts/_default/_markup/render-image.html
+++ b/layouts/_default/_markup/render-image.html
@@ -1,6 +1,7 @@
 {{- $alt := .Text | plainify -}}
 {{- if eq (len $alt) 0 -}}{{ warnf "Image missing alt text: %s" .Destination }}{{- end -}}
 {{- $title := .Title -}}
+{{- $location := cond (eq .Page.Section "locations") .Page.Title "Kingscliff" -}}
 {{- $img := .Page.Resources.GetMatch (printf "%s" .Destination) -}}
 {{- if $img -}}
   {{- $large := $img.Fit "1200x" -}}
@@ -11,8 +12,8 @@
   <picture>
     <source srcset="{{ $avif.RelPermalink }}" type="image/avif">
     <source srcset="{{ $webp.RelPermalink }}" type="image/webp">
-    <img src="{{ $large.RelPermalink }}" srcset="{{ $small.RelPermalink }} 400w, {{ $medium.RelPermalink }} 800w, {{ $large.RelPermalink }} 1200w" sizes="100vw" loading="lazy" alt="{{ $alt }}" {{ with $title }}title="{{ . }}"{{ end }} width="{{ $large.Width }}" height="{{ $large.Height }}">
+    <img src="{{ $large.RelPermalink }}" srcset="{{ $small.RelPermalink }} 400w, {{ $medium.RelPermalink }} 800w, {{ $large.RelPermalink }} 1200w" sizes="100vw" loading="lazy" alt="{{ $alt }} - Local Pest Co. {{ $location }} NSW" {{ with $title }}title="{{ . }}"{{ end }} width="{{ $large.Width }}" height="{{ $large.Height }}">
   </picture>
 {{- else -}}
-  <img src="{{ .Destination | relURL }}" alt="{{ $alt }}" {{ with $title }}title="{{ . }}"{{ end }} loading="lazy">
+  <img src="{{ .Destination | relURL }}" alt="{{ $alt }} - Local Pest Co. {{ $location }} NSW" {{ with $title }}title="{{ . }}"{{ end }} loading="lazy">
 {{- end -}}

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -19,7 +19,8 @@
   </div>
   <a class="skip-link" href="#main-content">Skip to content</a>
   <header>
-    <div class="logo"><a href="{{ "/" | relURL }}"><img src="{{ "/images/logo-placeholder.svg" | relURL }}" alt="{{ .Site.Title }} logo"></a></div>
+    {{- $location := cond (eq .Section "locations") .Title "Kingscliff" -}}
+    <div class="logo"><a href="{{ "/" | relURL }}"><img src="{{ "/images/logo-placeholder.svg" | relURL }}" alt="{{ .Site.Title }} logo - Local Pest Co. {{ $location }} NSW"></a></div>
     <nav class="main-nav">
       <ul>
         <li><a href="{{ "/" | relURL }}">Home</a></li>

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -3,7 +3,8 @@
   <h1>{{ .Title }}</h1>
   {{ range .Pages }}
   <article class="content-row">
-    <img src="{{ with .Params.image }}{{ . }}{{ else }}https://placehold.co/400x300{{ end }}" alt="{{ .Title }}" loading="lazy">
+    {{- $location := cond (eq .Section "locations") .Title "Kingscliff" -}}
+    <img src="{{ with .Params.image }}{{ . }}{{ else }}https://placehold.co/400x300{{ end }}" alt="{{ .Title }} - Local Pest Co. {{ $location }} NSW" loading="lazy">
     <div class="text">
       <h2><a href="{{ .RelPermalink }}">{{ .Title }}</a></h2>
       {{ with .Params.description }}<p>{{ . }}</p>{{ end }}

--- a/layouts/partials/banner.html
+++ b/layouts/partials/banner.html
@@ -1,3 +1,4 @@
+{{- $location := cond (eq .Section "locations") .Title "Kingscliff" -}}
 <div class="banner fade-in-element">
-  <img src="https://placehold.co/1600x400?text=Local+Pest+Co" alt="Local Pest Co banner">
+  <img src="https://placehold.co/1600x400?text=Local+Pest+Co" alt="Local Pest Co banner - Local Pest Co. {{ $location }} NSW">
 </div>

--- a/layouts/shortcodes/requestedimg.html
+++ b/layouts/shortcodes/requestedimg.html
@@ -1,3 +1,4 @@
 {{- $file := .Get "file" -}}
 {{- $alt := .Get "alt" -}}
-<img src="/image-requests/{{ $file }}" alt="{{ $alt }}" loading="lazy" onerror="this.onerror=null;this.src='https://placehold.co/600x300?text=Image+Coming+Soon';" />
+{{- $location := cond (eq .Page.Section "locations") .Page.Title "Kingscliff" -}}
+<img src="/image-requests/{{ $file }}" alt="{{ $alt }} - Local Pest Co. {{ $location }} NSW" loading="lazy" onerror="this.onerror=null;this.src='https://placehold.co/600x300?text=Image+Coming+Soon';" />


### PR DESCRIPTION
## Summary
- Append "Local Pest Co. <location> NSW" suffix to all image alt text
- Use page section to swap Kingscliff with location name on location pages
- Update logo and banner alt tags for SEO

## Testing
- `hugo --minify`

------
https://chatgpt.com/codex/tasks/task_e_68be92db0e0c83258e1c9fe0940bf172