### PR TITLE
Add legacy redirects and dynamic banner placeholders

### DIFF
--- a/layouts/partials/banner.html
+++ b/layouts/partials/banner.html
@@ -1,4 +1,9 @@
 {{- $location := cond (eq .Section "locations") .Title "Kingscliff" -}}
+{{- $banner := .Params.banner -}}
 <div class="banner fade-in-element">
-  <img src="https://placehold.co/1600x400?text=Local+Pest+Co" alt="Local Pest Co banner - Local Pest Co. {{ $location }} NSW">
+  {{- if $banner -}}
+    <img src="/image-requests/{{ $banner }}" alt="Local Pest Co banner - Local Pest Co. {{ $location }} NSW" loading="lazy" onerror="this.onerror=null;this.src='https://placehold.co/1600x400?text=Local+Pest+Co';" />
+  {{- else -}}
+    <img src="https://placehold.co/1600x400?text=Local+Pest+Co" alt="Local Pest Co banner - Local Pest Co. {{ $location }} NSW" />
+  {{- end -}}
 </div>

--- a/static/_redirects
+++ b/static/_redirects
@@ -1,0 +1,63 @@
+# Redirect old service pages to service landing page
+/ant-control-kingscliff/ /services 301
+/snake-control-kingscliff/ /services 301
+/eco-friendly-pest-control-kingscliff/ /services 301
+/termite-inspection-kingscliff/ /services 301
+/termite-control-kingscliff/ /services 301
+/cockroach-control-kingscliff/ /services 301
+/commercial-pest-control-kingscliff/ /services 301
+/emergency-pest-control-kingscliff/ /services 301
+/german-cockroach-control-kingscliff/ /services 301
+/spider-identification-kingscliff/ /services 301
+/possum-removal-kingscliff/ /services 301
+/bird-control-kingscliff/ /services 301
+/moth-control-kingscliff/ /services 301
+/tick-control-kingscliff/ /services 301
+/mosquito-control-kingscliff/ /services 301
+/residential-pest-control-in-kingscliff/ /services 301
+/rodent-control-kingscliff/ /services 301
+/silverfish-control-kingscliff/ /services 301
+/spider-control-kingscliff/ /services 301
+/wasp-and-bee-removal-kingscliff/ /services 301
+/flea-control-kingscliff/ /services 301
+/bed-bug-treatment-kingscliff/ /services 301
+/bed-bug-inspection-kingscliff/ /services 301
+
+# Redirect location pages to locations landing page
+/cabarita-beach/ /locations 301
+/casuarina/ /locations 301
+/chinderah/ /locations 301
+/cudgen/ /locations 301
+/fingal-head/ /locations 301
+/kingscliff/ /locations 301
+/pottsville/ /locations 301
+
+# Redirect posts to home page
+/commercial-pest-control-solutions-for-businesses-7-shocking-benefits/ / 301
+/pest-control-for-cafes-offices-and-shops-2025-secrets-revealed/ / 301
+/how-local-pest-companies-support-community-health-5-powerful-ways/ / 301
+/rodent-control-services-what-works-best-find-out-for-2025/ / 301
+/top-termite-treatment-options-in-australia-2025-kingscliff-guide/ / 301
+/choosing-a-safe-and-eco-friendly-pest-control-option-2025-guide/ / 301
+/number-of-nsw-smokers-drops-to-lowest-levels-on-record-see-how/ / 301
+/walk-on-country-kingscliff-discover-why-everyone-loves-it-in-2025/ / 301
+/why-regular-pest-inspections-are-crucial-for-kingscliff-businesses/ / 301
+/preparing-for-pests-after-the-kingscliff-triathlon-5-must-know-tips/ / 301
+/eco-friendly-pest-control-solutions-for-kingscliffs-coastal-homes-5-tips/ / 301
+/the-impact-of-humid-weather-on-cockroach-infestations-in-kingscliff/ / 301
+/how-recent-rainfall-in-kingscliff-may-increase-termite-activity-3/ / 301
+/how-recent-rainfall-in-kingscliff-may-increase-termite-activity-2/ / 301
+/how-coastal-humidity-in-kingscliff-affects-cockroach-and-ant-problems-2/ / 301
+/eco-friendly-pest-control-7-shocking-facts-you-must-know-for-2025/ / 301
+/pest-control-kingscliff-top-2025-tips-to-protect-your-home-now/ / 301
+/avoid-these-costly-termite-control-kingscliff-mistakes-now/ / 301
+
+# Redirect other taxonomy pages to home
+/category/* / 301
+/tag/* / 301
+/author/* / 301
+/news/* / 301
+
+# Existing pages
+/contact/ /contact/ 301
+/blog/ / 301


### PR DESCRIPTION
## Summary
- Add redirects mapping legacy service pages to `/services`, location pages to `/locations`, posts to home, and catch-all rules for other taxonomies
- Enable optional banner images via front matter with placeholder fallback

## Testing
- `hugo`


------
https://chatgpt.com/codex/tasks/task_e_68be9a6d6f7c83258d937d379cbb315b