### PR TITLE
Fix EPA link and display licence information

### DIFF
--- a/content/about.md
+++ b/content/about.md
@@ -16,4 +16,13 @@ answer = "All treatments include practical follow-up advice and a service guaran
 
 Founded and operated by me, an Aboriginal local, Local Pest Co combines my community knowledge with licensed pest management techniques for Kingscliff and surrounding suburbs. I focus on safe methods that respect families, pets, and the environment while keeping Tweed Coast homes pest-free.
 
+## Licence Details
+
+- Licence number: 5073077
+- Licence holder: Mr SHANNON KITCHENER
+- Status: Issued
+- Licence type: PMT-TP – Pest Management Technician (Timber Pest Control)
+- Date issued: 20/02/2025
+- Expiry date: 14/01/2030
+
 Call me on 0405 508 035 or email thelocalpestco@bigpond.com to book a visit.

--- a/content/termite-control-northern-rivers.md
+++ b/content/termite-control-northern-rivers.md
@@ -24,9 +24,9 @@ Termites thrive in the warm, humid conditions of the Northern Rivers. I focus on
 
 ## NSW Licensing & Regulations
 
-All termite work in New South Wales must be carried out by licensed professionals. I hold the required pest management technician licence issued by the NSW Environment Protection Authority ([EPA NSW](https://www.epa.nsw.gov.au/your-environment/pesticides/licences-and-permits/pest-management-technicians-and-businesses)).
+All termite work in New South Wales must be carried out by licensed professionals. I hold NSW EPA pest management technician licence number 5073077 ([EPA NSW](https://www.epa.nsw.gov.au/Your-environment/Pesticides/Licences-and-advice-for-occupational-pesticide-users/pest-management-technicians-fumigators-training-permits)), issued 20/02/2025 and valid until 14/01/2030.
 
-For homeowners, NSW Fair Trading provides guidance on engaging accredited pest controllers and understanding treatment options ([NSW Fair Trading - Pest Management](https://www.fairtrading.nsw.gov.au/housing-and-property/building-and-renovating/pest-management)).
+For homeowners, the EPA provides guidance on engaging accredited pest controllers and understanding treatment options ([EPA - Engaging a Pest Management Technician](https://www.epa.nsw.gov.au/Your-environment/Pesticides/pesticide-use-nsw/engaging-a-pest-management-technician)).
 
 ## Book a Northern Rivers Termite Inspection
 

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -96,6 +96,7 @@
   {{ partial "land-care.html" . }}
   <footer>
     <p>&copy; {{ now.Format "2006" }} {{ .Site.Title }}</p>
+    <p>Licence No. 5073077 | Licence holder: Mr SHANNON KITCHENER | Status: Issued | Licence type: PMT-TP – Pest Management Technician (Timber Pest Control) | Date issued: 20/02/2025 | Expiry date: 14/01/2030</p>
   </footer>
   <script src="{{ "/js/main.js" | relURL }}" defer></script>
 </body>


### PR DESCRIPTION
## Summary
- Update NSW EPA and guidance links to working URLs
- Surface pest management licence details in About page and global footer

## Testing
- `hugo --minify`

------
https://chatgpt.com/codex/tasks/task_e_68bea3b810508325b9e9711763786ee4