### PR TITLE
Add service modules to services page and navigation

### DIFF
--- a/content/services.md
+++ b/content/services.md
@@ -14,14 +14,24 @@ answer = "Yes, I strive to offer same-day or next-day visits across the Tweed Co
 
 {{< requestedimg file="services-1.jpg" alt="Technician applying eco-friendly pest spray around a Tweed Coast home" >}}
 
-I handle common pest issues with targeted treatments across Kingscliff, Casuarina, Cabarita Beach, and the wider Tweed Coast:
+I handle common pest issues with targeted treatments across Kingscliff, Casuarina, Cabarita Beach, and the wider Tweed Coast.
 
-- Termite inspections and treatment programs
-- Rodent management
-- Cockroach and ant solutions
-- Spider control
+## Pest Control Services
 
-For solutions tailored to your property, see our [residential pest control](/residential-pest-control/) and [commercial pest control](/commercial-pest-control/) services.
+### [Residential Pest Control](/residential-pest-control/)
+Safe, low-toxicity treatments for Tweed Coast homes.
+
+### [Commercial Pest Control](/commercial-pest-control/)
+Food-safe pest management for businesses.
+
+### [Timber Pest Control](/timber-pest-control/)
+Licensed inspections and treatments for timber pests.
+
+### [Eco-Friendly Pest Control](/eco-friendly-pest-control/)
+Environmentally conscious pest solutions.
+
+### [Termite Control](/termite-control-northern-rivers/)
+Targeted termite inspections and treatment programs.
 
 Every visit includes practical advice for prevention and long-term pest management.
 

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -28,8 +28,7 @@
         <li class="dropdown">
           <a href="{{ "/services/" | relURL }}">Services</a>
           <ul class="dropdown-menu">
-            <li><a href="{{ "/eco-friendly-pest-control/" | relURL }}">Eco-Friendly Pest Control</a></li>
-            <li><a href="{{ "/termite-control-northern-rivers/" | relURL }}">Termite Control</a></li>
+            {{ partial "services-menu.html" . }}
           </ul>
         </li>
         <li class="dropdown">
@@ -66,8 +65,7 @@
         <li class="dropdown">
           <a href="{{ "/services/" | relURL }}">Services</a>
           <ul class="dropdown-menu">
-            <li><a href="{{ "/eco-friendly-pest-control/" | relURL }}">Eco-Friendly Pest Control</a></li>
-            <li><a href="{{ "/termite-control-northern-rivers/" | relURL }}">Termite Control</a></li>
+            {{ partial "services-menu.html" . }}
           </ul>
         </li>
         <li class="dropdown">

--- a/layouts/partials/services-menu.html
+++ b/layouts/partials/services-menu.html
@@ -1,0 +1,5 @@
+<li><a href="{{ "/residential-pest-control/" | relURL }}">Residential Pest Control</a></li>
+<li><a href="{{ "/commercial-pest-control/" | relURL }}">Commercial Pest Control</a></li>
+<li><a href="{{ "/timber-pest-control/" | relURL }}">Timber Pest Control</a></li>
+<li><a href="{{ "/eco-friendly-pest-control/" | relURL }}">Eco-Friendly Pest Control</a></li>
+<li><a href="{{ "/termite-control-northern-rivers/" | relURL }}">Termite Control</a></li>


### PR DESCRIPTION
## Summary
- list all pest control offerings on the services landing page with links to individual modules
- reuse a single partial for service links in desktop and mobile navigation

## Testing
- `hugo`
- `npx --yes linkinator public`


------
https://chatgpt.com/codex/tasks/task_e_68bea69685108325a26c79be474f7734