### PR TITLE
Add dark overlay to banner and move page titles onto it

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,6 +1,5 @@
 {{ define "main" }}
 <section class="page-list">
-  <h1>{{ .Title }}</h1>
   {{ range .Pages }}
   <article class="content-row">
     {{- $location := cond (eq .Section "locations") .Title "Kingscliff" -}}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,6 +1,5 @@
 {{ define "main" }}
 <article>
-  <h1>{{ .Title }}</h1>
   {{ .Content }}
 </article>
 {{ partial "faq.html" . }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,6 +1,5 @@
 {{ define "main" }}
 <section>
-  <h1>{{ .Title }}</h1>
   {{ .Content }}
 </section>
 {{ end }}

--- a/layouts/partials/banner.html
+++ b/layouts/partials/banner.html
@@ -2,4 +2,6 @@
 {{- $banner := .Params.banner | default "banner.jpg" -}}
 <div class="banner fade-in-element">
   <img src="/image-requests/{{ $banner }}" alt="Local Pest Co banner - Local Pest Co. {{ $location }} NSW" loading="lazy" onerror="this.onerror=null;this.src='https://placehold.co/1600x400?text=Local+Pest+Co';" />
+  <div class="banner-overlay" aria-hidden="true"></div>
+  <h1 class="banner-title">{{ .Title }}</h1>
 </div>

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -219,11 +219,35 @@ main {
   background-color: var(--color-light-bg);
 }
 
+.banner {
+  position: relative;
+}
+
 .banner img {
   width: 100%;
   height: 400px;
   object-fit: cover;
   display: block;
+}
+
+.banner-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.5);
+}
+
+.banner-title {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  color: #fff;
+  font-size: 3rem;
+  margin: 0;
+  text-align: center;
 }
 
 .fade-in-element {


### PR DESCRIPTION
## Summary
- Add reusable dark overlay and title text to the page banner
- Center banner titles and enlarge them for better prominence
- Remove redundant H1 headings from page templates

## Testing
- `hugo`

------
https://chatgpt.com/codex/tasks/task_e_68beadfa8c0c83258bc81d2ff79eda77