### PR TITLE
Add SEO-friendly blog section and koala sanctuary article

### DIFF
--- a/archetypes/blog.md
+++ b/archetypes/blog.md
@@ -1,0 +1,8 @@
++++
+title = '{{ replace .File.ContentBaseName "-" " " | title }}'
+date = {{ .Date }}
+meta_desc = ''
+author = 'Local Pest Co'
+tags = []
+images = []
++++

--- a/content/blog/_index.md
+++ b/content/blog/_index.md
@@ -1,0 +1,4 @@
++++
+title = "Blog"
+meta_desc = "Insights and news on wildlife protection and sustainable land care from Local Pest Co."
++++

--- a/content/blog/australia-koala-sanctuary.md
+++ b/content/blog/australia-koala-sanctuary.md
@@ -1,0 +1,17 @@
++++
+title = "Australia creates koala sanctuary to protect wildlife for future generations"
+date = 2025-09-07T11:20:00+10:00
+meta_desc = "New South Wales halts logging to establish the Great Koala National Park, safeguarding koalas and other species while preserving forests for generations to come."
+author = "Local Pest Co"
+tags = ["wildlife", "conservation", "koalas", "forests"]
++++
+
+Australia has taken a bold step to protect its iconic wildlife by suspending logging operations across 176,000 hectares of forest on the eastern coast. The New South Wales government is transforming this vast woodland into the Great Koala National Park, a sanctuary intended to prevent koalas from disappearing from the region.
+
+Halting deforestation in these tall eucalypt forests provides immediate relief for more than 12,000 koalas and 36,000 greater gliders, along with over 100 other threatened species. The move also supports the health of the land itself, allowing native trees to regenerate and creating a resilient habitat that can better withstand droughts and bushfires.
+
+Protecting these forests is about more than saving animals today. By preserving large, connected areas of native bushland, Australia is investing in a stable environment for future generations. The park will serve as a climate refuge, shielding wildlife from rising temperatures while offering communities new opportunities in sustainable tourism and education.
+
+Land set aside for conservation plays a vital role in the broader ecosystem. Trees store carbon, prevent erosion, and maintain the soil and water systems that humans and animals rely on. As the Great Koala National Park takes shape, it stands as a reminder that caring for wildlife and the land goes hand in hand with building a healthier future for everyone.
+
+By valuing nature and limiting destructive practices, New South Wales is setting a precedent for long-term stewardship. Preserving land today ensures that koalas—and the forests they call home—remain part of Australia’s landscape for generations to come.

--- a/hugo.toml
+++ b/hugo.toml
@@ -8,6 +8,7 @@ enableGitInfo = true
 
 [outputs]
 home = ['HTML', 'RSS', 'Robots']
+section = ['HTML', 'RSS']
 
 [outputFormats]
   [outputFormats.Robots]

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -43,6 +43,7 @@
             <li><a href="{{ "/locations/pottsville/" | relURL }}">Pottsville</a></li>
           </ul>
         </li>
+        <li><a href="{{ "/blog/" | relURL }}">Blog</a></li>
         <li><a href="{{ "/about/" | relURL }}">About</a></li>
         <li><a href="{{ "/contact/" | relURL }}">Contact</a></li>
       </ul>
@@ -80,6 +81,7 @@
             <li><a href="{{ "/locations/pottsville/" | relURL }}">Pottsville</a></li>
           </ul>
         </li>
+        <li><a href="{{ "/blog/" | relURL }}">Blog</a></li>
         <li><a href="{{ "/about/" | relURL }}">About</a></li>
         <li><a href="{{ "/contact/" | relURL }}">Contact</a></li>
       </ul>

--- a/layouts/blog/list.html
+++ b/layouts/blog/list.html
@@ -1,0 +1,11 @@
+{{ define "main" }}
+<section class="blog-list">
+  {{ range .Pages.ByDate.Reverse }}
+  <article class="post-preview">
+    <h2><a href="{{ .RelPermalink }}">{{ .Title }}</a></h2>
+    <p class="post-meta">{{ .Date.Format "2006-01-02" }}</p>
+    {{ with .Params.meta_desc }}<p>{{ . }}</p>{{ else }}<p>{{ .Summary }}</p>{{ end }}
+  </article>
+  {{ end }}
+</section>
+{{ end }}

--- a/layouts/blog/single.html
+++ b/layouts/blog/single.html
@@ -1,0 +1,12 @@
+{{ define "main" }}
+<article class="blog-post">
+  <header>
+    <h1>{{ .Title }}</h1>
+    <p class="post-meta">
+      <time datetime="{{ .Date.Format "2006-01-02" }}">{{ .Date.Format "January 2, 2006" }}</time>
+      {{ with .Params.author }} &bull; <span class="author">{{ . }}</span>{{ end }}
+    </p>
+  </header>
+  {{ .Content }}
+</article>
+{{ end }}


### PR DESCRIPTION
## Summary
- add blog section with list/single layouts and archetype
- link blog in main navigation and enable section RSS
- publish first post on Australia's Great Koala National Park

## Testing
- `hugo --gc --minify`
- `htmltest` *(fails: command not found)*
- `html-validate public/**/*.html` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68beb09b15d0832599e3dd4575842acc