### PR TITLE
Animate canvas-based loading screen

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -15,8 +15,7 @@
 </head>
 <body>
   <div id="splash-screen" aria-hidden="true">
-    <div class="message aboriginal">Jingi Walla</div>
-    <div class="message english">Welcome</div>
+    <canvas id="flag"></canvas>
   </div>
   <a class="skip-link" href="#main-content">Skip to content</a>
   <header>

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -333,8 +333,7 @@ main {
   left: 0;
   width: 100%;
   height: 100%;
-  background: var(--color-light-bg);
-  color: var(--color-black);
+  background: #000;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -343,27 +342,14 @@ main {
   transition: opacity 2s ease;
 }
 
+#splash-screen canvas {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
 .seen-splash #splash-screen {
   display: none;
-}
-
-#splash-screen .message {
-  position: absolute;
-  font-size: 2rem;
-  font-weight: bold;
-  transition: opacity 2s ease;
-}
-
-#splash-screen .english {
-  opacity: 0;
-}
-
-#splash-screen.fade-english .aboriginal {
-  opacity: 0;
-}
-
-#splash-screen.fade-english .english {
-  opacity: 1;
 }
 
 #splash-screen.hide {

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -68,15 +68,69 @@ document.addEventListener('DOMContentLoaded', () => {
     } else {
       window.addEventListener('load', () => {
         document.cookie = 'splashSeen=true; path=/; max-age=31536000';
-        setTimeout(() => {
-          splash.classList.add('fade-english');
-        }, 1000);
+        const canvas = document.getElementById('flag');
+        if (canvas) {
+          const ctx = canvas.getContext('2d');
+          const resize = () => {
+            canvas.width = window.innerWidth;
+            canvas.height = window.innerHeight;
+          };
+          resize();
+          window.addEventListener('resize', resize);
+          let phase = 0;
+          let split = 0;
+          let yellowAlpha = 1;
+          let showWelcome = true;
+          const draw = () => {
+            const w = canvas.width;
+            const h = canvas.height;
+            ctx.clearRect(0, 0, w, h);
+            if (phase === 0) {
+              ctx.fillStyle = '#000';
+              ctx.fillRect(0, 0, w, h / 2);
+              ctx.fillStyle = '#c60000';
+              ctx.fillRect(0, h / 2, w, h / 2);
+            } else {
+              ctx.fillStyle = '#000';
+              ctx.fillRect(-split, 0, w, h / 2);
+              ctx.fillStyle = '#c60000';
+              ctx.fillRect(split, h / 2, w, h / 2);
+            }
+            ctx.fillStyle = `rgba(255,255,0,${yellowAlpha})`;
+            ctx.beginPath();
+            ctx.arc(w / 2, h / 2, Math.min(w, h) / 4, 0, Math.PI * 2);
+            ctx.fill();
+            if (showWelcome) {
+              ctx.fillStyle = '#fff';
+              ctx.font = `${Math.min(w, h) / 12}px sans-serif`;
+              ctx.textAlign = 'center';
+              ctx.fillText('Welcome', w / 2, h / 2 + Math.min(w, h) / 24);
+            }
+            requestAnimationFrame(draw);
+          };
+          const startSplit = () => {
+            phase = 1;
+            const splitTimer = setInterval(() => {
+              split += 8;
+              if (split >= canvas.width / 2) clearInterval(splitTimer);
+            }, 30);
+            setTimeout(() => {
+              showWelcome = false;
+              const fadeTimer = setInterval(() => {
+                yellowAlpha -= 0.02;
+                if (yellowAlpha <= 0) clearInterval(fadeTimer);
+              }, 30);
+            }, 1500);
+          };
+          draw();
+          setTimeout(startSplit, 1000);
+        }
         setTimeout(() => {
           splash.classList.add('hide');
-        }, 3000);
+        }, 4500);
         setTimeout(() => {
           splash.remove();
-        }, 5000);
+        }, 6500);
       });
     }
   }


### PR DESCRIPTION
## Summary
- Replace splash screen HTML with canvas element for animated flag loader
- Add CSS styling for full-screen canvas and hide behavior
- Implement JavaScript animation to split colors and fade yellow circle

## Testing
- `hugo --minify`

------
https://chatgpt.com/codex/tasks/task_e_68beb80947f8832582889d4551ad21cc