### PR TITLE
Remove outdated blog redirect

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -58,5 +58,3 @@
 /author/* / 301
 /news/* / 301
 
-# Existing pages
-/blog/ / 301


### PR DESCRIPTION
## Summary
- remove /blog -> / redirect now that blog posts exist

## Testing
- `hugo`


------
https://chatgpt.com/codex/tasks/task_e_68bf51d7372883259e60fd8d20352854