### PR TITLE
Separate business and personal socials

### DIFF
--- a/content/about.md
+++ b/content/about.md
@@ -20,7 +20,17 @@ Founded and operated by me, an *Aboriginal* local, **Local Pest Co** combines my
 
 Shannon Kitchener is an avid fly fisher who explores regional parts of Australia, building connections with Country and its Traditional Owners. When he isn't on the water, Shannon paints traditional art—the same vibrant style featured in our banner. He also runs **[X-stream Fly Sportfishing Tours](https://www.facebook.com/xstreamfly/)**, sharing his love of angling with others.
 
-### Connect with Shannon
+### Connect with Local Pest Co
+
+<div class="social-links">
+  <a href="https://www.facebook.com/Localpestco/" aria-label="Local Pest Co on Facebook">
+    <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M22 12.07C22 6.46 17.52 2 12 2S2 6.46 2 12.07C2 17.1 5.66 21.23 10.44 22v-7.03H7.9v-2.9h2.54V9.84c0-2.5 1.49-3.89 3.77-3.89 1.09 0 2.23.2 2.23.2v2.46h-1.25c-1.23 0-1.62.77-1.62 1.56v1.87h2.77l-.44 2.9h-2.33V22C18.34 21.23 22 17.1 22 12.07z"/></svg>
+  </a>
+</div>
+
+### Shannon's Fly Fishing Socials
+
+Shannon's fishing tours, **X-stream Fly Sportfishing Tours**, have their own channels:
 
 <div class="social-links">
   <a href="https://www.facebook.com/xstreamfly/" aria-label="X-stream Fly Sportfishing Tours on Facebook">

--- a/content/contact.md
+++ b/content/contact.md
@@ -30,6 +30,18 @@ I serve Kingscliff, the Tweed Coast, and nearby regions. Call or email me to arr
 
 ### Connect on Social Media
 
+#### Local Pest Co
+
+<div class="social-links">
+  <a href="https://www.facebook.com/Localpestco/" aria-label="Local Pest Co on Facebook">
+    <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M22 12.07C22 6.46 17.52 2 12 2S2 6.46 2 12.07C2 17.1 5.66 21.23 10.44 22v-7.03H7.9v-2.9h2.54V9.84c0-2.5 1.49-3.89 3.77-3.89 1.09 0 2.23.2 2.23.2v2.46h-1.25c-1.23 0-1.62.77-1.62 1.56v1.87h2.77l-.44 2.9h-2.33V22C18.34 21.23 22 17.1 22 12.07z"/></svg>
+  </a>
+</div>
+
+#### X-stream Fly Sportfishing Tours
+
+Shannon's fly fishing business maintains separate social channels:
+
 <div class="social-links">
   <a href="https://www.facebook.com/xstreamfly/" aria-label="X-stream Fly Sportfishing Tours on Facebook">
     <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M22 12.07C22 6.46 17.52 2 12 2S2 6.46 2 12.07C2 17.1 5.66 21.23 10.44 22v-7.03H7.9v-2.9h2.54V9.84c0-2.5 1.49-3.89 3.77-3.89 1.09 0 2.23.2 2.23.2v2.46h-1.25c-1.23 0-1.62.77-1.62 1.56v1.87h2.77l-.44 2.9h-2.33V22C18.34 21.23 22 17.1 22 12.07z"/></svg>

--- a/hugo.toml
+++ b/hugo.toml
@@ -28,6 +28,9 @@ section = ['HTML', 'RSS']
   titleSuffix = ''
   # Google Analytics ID (GA4)
   ga_id = 'G-E3J58VK95M'
+  # logo used in header, favicon, and structured data
+  logo = '/images/logo-placeholder.svg'
   # social accounts
   [params.social]
+    facebook = 'https://www.facebook.com/Localpestco/'
     twitter = ''

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -8,6 +8,7 @@
   {{ partial "analytics.html" . }}
   <link href="https://fonts.googleapis.com/css2?family=Knewave&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="{{ "/css/style.css" | relURL }}">
+  <link rel="icon" href="{{ .Site.Params.logo | relURL }}" type="image/svg+xml">
   <script>
     if (document.cookie.split(';').some(c => c.trim() === 'splashSeen=true')) {
       document.documentElement.classList.add('seen-splash');
@@ -21,7 +22,7 @@
   </div>
   <a class="skip-link" href="#main-content">Skip to content</a>
   <header>
-    <div class="logo"><a href="{{ "/" | relURL }}"><img src="{{ "/images/logo-placeholder.svg" | relURL }}" alt="{{ .Site.Title }} logo"></a></div>
+    <div class="logo"><a href="{{ "/" | relURL }}"><img src="{{ .Site.Params.logo | relURL }}" alt="{{ .Site.Title }} logo"></a></div>
     <nav class="main-nav">
       <ul>
         <li><a href="{{ "/" | relURL }}">Home</a></li>
@@ -97,11 +98,8 @@
   <footer>
     <p>&copy; {{ now.Format "2006" }} {{ .Site.Title }}</p>
     <div class="social-links">
-      <a href="https://www.facebook.com/xstreamfly/" aria-label="X-stream Fly Sportfishing Tours on Facebook">
+      <a href="https://www.facebook.com/Localpestco/" aria-label="Local Pest Co on Facebook">
         <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M22 12.07C22 6.46 17.52 2 12 2S2 6.46 2 12.07C2 17.1 5.66 21.23 10.44 22v-7.03H7.9v-2.9h2.54V9.84c0-2.5 1.49-3.89 3.77-3.89 1.09 0 2.23.2 2.23.2v2.46h-1.25c-1.23 0-1.62.77-1.62 1.56v1.87h2.77l-.44 2.9h-2.33V22C18.34 21.23 22 17.1 22 12.07z"/></svg>
-      </a>
-      <a href="https://www.instagram.com/xstream_fly/" aria-label="X-stream Fly Sportfishing Tours on Instagram">
-        <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M7 2C4.24 2 2 4.24 2 7v10c0 2.76 2.24 5 5 5h10c2.76 0 5-2.24 5-5V7c0-2.76-2.24-5-5-5H7zm10 2a3 3 0 013 3v10a3 3 0 01-3 3H7a3 3 0 01-3-3V7a3 3 0 013-3h10zm-5 3a5 5 0 100 10 5 5 0 000-10zm0 2a3 3 0 110 6 3 3 0 010-6zm4.5-2.75a1.25 1.25 0 100 2.5 1.25 1.25 0 000-2.5z"/></svg>
       </a>
     </div>
     <p>Licence No. 5073077 | Licence holder: Mr SHANNON KITCHENER | Status: Issued | Licence type: PMT-TP – Pest Management Technician (Timber Pest Control) | Date issued: 20/02/2025 | Expiry date: 14/01/2030</p>


### PR DESCRIPTION
## Summary
- Feature Local Pest Co's Facebook account separately from Shannon's fly fishing socials on About and Contact pages
- Use site logo for favicon, header, and structured data
- Replace footer socials with a link to Local Pest Co's Facebook page

## Testing
- `hugo --minify`

------
https://chatgpt.com/codex/tasks/task_e_68bf5804081483258ebc600ad43bd78b