### PR TITLE
Add Kingscliff cornerstone, termite hub and suburb service pages

### DIFF
--- a/content/ant-control-cabarita.md
+++ b/content/ant-control-cabarita.md
@@ -1,0 +1,69 @@
++++
+title = "Ant Control Cabarita | Eco-Friendly & Licensed | Local Pest Co"
+meta_desc = "Local, low-tox ant control in Cabarita. Licensed techs, fast call-outs, clear pricing. Book today: 0405 508 035."
+[service]
+serviceType = "Ant Control"
+areaServed = "Cabarita"
+priceRange = "$220"
+[[faq]]
+question = "Do you remove snakes?"
+answer = "We don’t remove snakes. For safety, please contact a licensed snake catcher. If a snake is inside, keep clear and close interior doors until help arrives."
+[[faq]]
+question = "Do you handle mammals like possums, rats, or mice?"
+answer = "We don’t handle mammals. We focus on termites and small insects. Please contact licensed wildlife or rodent specialists for these."
+[[faq]]
+question = "Do you remove birds or bats?"
+answer = "We don’t manage birds or bats. Seek licensed wildlife handlers and follow NSW regulations."
+[[faq]]
+question = "How long does ant treatment last?"
+answer = "Residual sprays and baits usually keep ants away for 6–12 months depending on conditions."
+[[faq]]
+question = "Are your ant gels safe for pets?"
+answer = "Yes, we use low-tox gels and granules that are placed out of reach of curious pets."
++++
+
+# Ant Control in Cabarita – Eco-Friendly & Licensed
+
+We deliver ant control across Cabarita. Our licensed techs use low-tox products
+that keep families, pets and the coast safe. Call 0405 508 035 for fast help or
+a quote today.
+
+**Call 0405 508 035**
+
+## Why choose us
+
+- Local technicians based near the Tweed Coast
+- Low-tox methods safe for kids and pets
+- Clear pricing and written reports
+
+## What’s included / excluded
+
+Includes: onsite assessment, targeted ant control and follow-up advice. Excludes: snakes, mammals, birds or reptiles.
+
+## Pricing & timing
+
+Ant treatments in Cabarita start from $220 and are usually wrapped up within an hour.
+
+## Our process
+
+1. Call or book online to schedule a visit.
+2. We inspect and identify the pests and entry points.
+3. We treat the problem with low-tox methods suited to your property.
+4. We provide a report and tips to keep pests away.
+
+## Local proof
+
+We’re based in Kingscliff and regularly service Cabarita and nearby spots like Murwillumbah and Chinderah.
+
+## Reviews
+
+> “Prompt and professional.” – Sarah M
+> “No more pests after one visit.” – Jake R
+
+## More help
+
+Need termite control? See our [Termite Control in Cabarita](/termite-control-cabarita/).
+
+Looking for termite inspections? Check out [Termite Inspections in Cabarita](/termite-inspections-cabarita/).
+
+Ready for ant control? **Call 0405 508 035**.

--- a/content/ant-control-casuarina.md
+++ b/content/ant-control-casuarina.md
@@ -1,0 +1,69 @@
++++
+title = "Ant Control Casuarina | Eco-Friendly & Licensed | Local Pest Co"
+meta_desc = "Local, low-tox ant control in Casuarina. Licensed techs, fast call-outs, clear pricing. Book today: 0405 508 035."
+[service]
+serviceType = "Ant Control"
+areaServed = "Casuarina"
+priceRange = "$220"
+[[faq]]
+question = "Do you remove snakes?"
+answer = "We don’t remove snakes. For safety, please contact a licensed snake catcher. If a snake is inside, keep clear and close interior doors until help arrives."
+[[faq]]
+question = "Do you handle mammals like possums, rats, or mice?"
+answer = "We don’t handle mammals. We focus on termites and small insects. Please contact licensed wildlife or rodent specialists for these."
+[[faq]]
+question = "Do you remove birds or bats?"
+answer = "We don’t manage birds or bats. Seek licensed wildlife handlers and follow NSW regulations."
+[[faq]]
+question = "How long does ant treatment last?"
+answer = "Residual sprays and baits usually keep ants away for 6–12 months depending on conditions."
+[[faq]]
+question = "Are your ant gels safe for pets?"
+answer = "Yes, we use low-tox gels and granules that are placed out of reach of curious pets."
++++
+
+# Ant Control in Casuarina – Eco-Friendly & Licensed
+
+We deliver ant control across Casuarina. Our licensed techs use low-tox products
+that keep families, pets and the coast safe. Call 0405 508 035 for fast help or
+a quote today.
+
+**Call 0405 508 035**
+
+## Why choose us
+
+- Local technicians based near the Tweed Coast
+- Low-tox methods safe for kids and pets
+- Clear pricing and written reports
+
+## What’s included / excluded
+
+Includes: onsite assessment, targeted ant control and follow-up advice. Excludes: snakes, mammals, birds or reptiles.
+
+## Pricing & timing
+
+Ant treatments in Casuarina start from $220 and are usually wrapped up within an hour.
+
+## Our process
+
+1. Call or book online to schedule a visit.
+2. We inspect and identify the pests and entry points.
+3. We treat the problem with low-tox methods suited to your property.
+4. We provide a report and tips to keep pests away.
+
+## Local proof
+
+We’re based in Kingscliff and regularly service Casuarina and nearby spots like Pottsville and Cabarita.
+
+## Reviews
+
+> “Prompt and professional.” – Sarah M
+> “No more pests after one visit.” – Jake R
+
+## More help
+
+Need termite control? See our [Termite Control in Casuarina](/termite-control-casuarina/).
+
+Looking for termite inspections? Check out [Termite Inspections in Casuarina](/termite-inspections-casuarina/).
+
+Ready for ant control? **Call 0405 508 035**.

--- a/content/ant-control-chinderah.md
+++ b/content/ant-control-chinderah.md
@@ -1,0 +1,69 @@
++++
+title = "Ant Control Chinderah | Eco-Friendly & Licensed | Local Pest Co"
+meta_desc = "Local, low-tox ant control in Chinderah. Licensed techs, fast call-outs, clear pricing. Book today: 0405 508 035."
+[service]
+serviceType = "Ant Control"
+areaServed = "Chinderah"
+priceRange = "$220"
+[[faq]]
+question = "Do you remove snakes?"
+answer = "We don’t remove snakes. For safety, please contact a licensed snake catcher. If a snake is inside, keep clear and close interior doors until help arrives."
+[[faq]]
+question = "Do you handle mammals like possums, rats, or mice?"
+answer = "We don’t handle mammals. We focus on termites and small insects. Please contact licensed wildlife or rodent specialists for these."
+[[faq]]
+question = "Do you remove birds or bats?"
+answer = "We don’t manage birds or bats. Seek licensed wildlife handlers and follow NSW regulations."
+[[faq]]
+question = "How long does ant treatment last?"
+answer = "Residual sprays and baits usually keep ants away for 6–12 months depending on conditions."
+[[faq]]
+question = "Are your ant gels safe for pets?"
+answer = "Yes, we use low-tox gels and granules that are placed out of reach of curious pets."
++++
+
+# Ant Control in Chinderah – Eco-Friendly & Licensed
+
+We deliver ant control across Chinderah. Our licensed techs use low-tox products
+that keep families, pets and the coast safe. Call 0405 508 035 for fast help or
+a quote today.
+
+**Call 0405 508 035**
+
+## Why choose us
+
+- Local technicians based near the Tweed Coast
+- Low-tox methods safe for kids and pets
+- Clear pricing and written reports
+
+## What’s included / excluded
+
+Includes: onsite assessment, targeted ant control and follow-up advice. Excludes: snakes, mammals, birds or reptiles.
+
+## Pricing & timing
+
+Ant treatments in Chinderah start from $220 and are usually wrapped up within an hour.
+
+## Our process
+
+1. Call or book online to schedule a visit.
+2. We inspect and identify the pests and entry points.
+3. We treat the problem with low-tox methods suited to your property.
+4. We provide a report and tips to keep pests away.
+
+## Local proof
+
+We’re based in Kingscliff and regularly service Chinderah and nearby spots like Cudgen and Casuarina.
+
+## Reviews
+
+> “Prompt and professional.” – Sarah M
+> “No more pests after one visit.” – Jake R
+
+## More help
+
+Need termite control? See our [Termite Control in Chinderah](/termite-control-chinderah/).
+
+Looking for termite inspections? Check out [Termite Inspections in Chinderah](/termite-inspections-chinderah/).
+
+Ready for ant control? **Call 0405 508 035**.

--- a/content/ant-control-cudgen.md
+++ b/content/ant-control-cudgen.md
@@ -1,0 +1,69 @@
++++
+title = "Ant Control Cudgen | Eco-Friendly & Licensed | Local Pest Co"
+meta_desc = "Local, low-tox ant control in Cudgen. Licensed techs, fast call-outs, clear pricing. Book today: 0405 508 035."
+[service]
+serviceType = "Ant Control"
+areaServed = "Cudgen"
+priceRange = "$220"
+[[faq]]
+question = "Do you remove snakes?"
+answer = "We don’t remove snakes. For safety, please contact a licensed snake catcher. If a snake is inside, keep clear and close interior doors until help arrives."
+[[faq]]
+question = "Do you handle mammals like possums, rats, or mice?"
+answer = "We don’t handle mammals. We focus on termites and small insects. Please contact licensed wildlife or rodent specialists for these."
+[[faq]]
+question = "Do you remove birds or bats?"
+answer = "We don’t manage birds or bats. Seek licensed wildlife handlers and follow NSW regulations."
+[[faq]]
+question = "How long does ant treatment last?"
+answer = "Residual sprays and baits usually keep ants away for 6–12 months depending on conditions."
+[[faq]]
+question = "Are your ant gels safe for pets?"
+answer = "Yes, we use low-tox gels and granules that are placed out of reach of curious pets."
++++
+
+# Ant Control in Cudgen – Eco-Friendly & Licensed
+
+We deliver ant control across Cudgen. Our licensed techs use low-tox products
+that keep families, pets and the coast safe. Call 0405 508 035 for fast help or
+a quote today.
+
+**Call 0405 508 035**
+
+## Why choose us
+
+- Local technicians based near the Tweed Coast
+- Low-tox methods safe for kids and pets
+- Clear pricing and written reports
+
+## What’s included / excluded
+
+Includes: onsite assessment, targeted ant control and follow-up advice. Excludes: snakes, mammals, birds or reptiles.
+
+## Pricing & timing
+
+Ant treatments in Cudgen start from $220 and are usually wrapped up within an hour.
+
+## Our process
+
+1. Call or book online to schedule a visit.
+2. We inspect and identify the pests and entry points.
+3. We treat the problem with low-tox methods suited to your property.
+4. We provide a report and tips to keep pests away.
+
+## Local proof
+
+We’re based in Kingscliff and regularly service Cudgen and nearby spots like Casuarina and Pottsville.
+
+## Reviews
+
+> “Prompt and professional.” – Sarah M
+> “No more pests after one visit.” – Jake R
+
+## More help
+
+Need termite control? See our [Termite Control in Cudgen](/termite-control-cudgen/).
+
+Looking for termite inspections? Check out [Termite Inspections in Cudgen](/termite-inspections-cudgen/).
+
+Ready for ant control? **Call 0405 508 035**.

--- a/content/ant-control-murwillumbah.md
+++ b/content/ant-control-murwillumbah.md
@@ -1,0 +1,69 @@
++++
+title = "Ant Control Murwillumbah | Eco-Friendly & Licensed | Local Pest Co"
+meta_desc = "Local, low-tox ant control in Murwillumbah. Licensed techs, fast call-outs, clear pricing. Book today: 0405 508 035."
+[service]
+serviceType = "Ant Control"
+areaServed = "Murwillumbah"
+priceRange = "$220"
+[[faq]]
+question = "Do you remove snakes?"
+answer = "We don’t remove snakes. For safety, please contact a licensed snake catcher. If a snake is inside, keep clear and close interior doors until help arrives."
+[[faq]]
+question = "Do you handle mammals like possums, rats, or mice?"
+answer = "We don’t handle mammals. We focus on termites and small insects. Please contact licensed wildlife or rodent specialists for these."
+[[faq]]
+question = "Do you remove birds or bats?"
+answer = "We don’t manage birds or bats. Seek licensed wildlife handlers and follow NSW regulations."
+[[faq]]
+question = "How long does ant treatment last?"
+answer = "Residual sprays and baits usually keep ants away for 6–12 months depending on conditions."
+[[faq]]
+question = "Are your ant gels safe for pets?"
+answer = "Yes, we use low-tox gels and granules that are placed out of reach of curious pets."
++++
+
+# Ant Control in Murwillumbah – Eco-Friendly & Licensed
+
+We deliver ant control across Murwillumbah. Our licensed techs use low-tox
+products that keep families, pets and the coast safe. Call 0405 508 035 for fast
+help or a quote today.
+
+**Call 0405 508 035**
+
+## Why choose us
+
+- Local technicians based near the Tweed Coast
+- Low-tox methods safe for kids and pets
+- Clear pricing and written reports
+
+## What’s included / excluded
+
+Includes: onsite assessment, targeted ant control and follow-up advice. Excludes: snakes, mammals, birds or reptiles.
+
+## Pricing & timing
+
+Ant treatments in Murwillumbah start from $220 and are usually wrapped up within an hour.
+
+## Our process
+
+1. Call or book online to schedule a visit.
+2. We inspect and identify the pests and entry points.
+3. We treat the problem with low-tox methods suited to your property.
+4. We provide a report and tips to keep pests away.
+
+## Local proof
+
+We’re based in Kingscliff and regularly service Murwillumbah and nearby spots like Chinderah and Cudgen.
+
+## Reviews
+
+> “Prompt and professional.” – Sarah M
+> “No more pests after one visit.” – Jake R
+
+## More help
+
+Need termite control? See our [Termite Control in Murwillumbah](/termite-control-murwillumbah/).
+
+Looking for termite inspections? Check out [Termite Inspections in Murwillumbah](/termite-inspections-murwillumbah/).
+
+Ready for ant control? **Call 0405 508 035**.

--- a/content/ant-control-pottsville.md
+++ b/content/ant-control-pottsville.md
@@ -1,0 +1,69 @@
++++
+title = "Ant Control Pottsville | Eco-Friendly & Licensed | Local Pest Co"
+meta_desc = "Local, low-tox ant control in Pottsville. Licensed techs, fast call-outs, clear pricing. Book today: 0405 508 035."
+[service]
+serviceType = "Ant Control"
+areaServed = "Pottsville"
+priceRange = "$220"
+[[faq]]
+question = "Do you remove snakes?"
+answer = "We don’t remove snakes. For safety, please contact a licensed snake catcher. If a snake is inside, keep clear and close interior doors until help arrives."
+[[faq]]
+question = "Do you handle mammals like possums, rats, or mice?"
+answer = "We don’t handle mammals. We focus on termites and small insects. Please contact licensed wildlife or rodent specialists for these."
+[[faq]]
+question = "Do you remove birds or bats?"
+answer = "We don’t manage birds or bats. Seek licensed wildlife handlers and follow NSW regulations."
+[[faq]]
+question = "How long does ant treatment last?"
+answer = "Residual sprays and baits usually keep ants away for 6–12 months depending on conditions."
+[[faq]]
+question = "Are your ant gels safe for pets?"
+answer = "Yes, we use low-tox gels and granules that are placed out of reach of curious pets."
++++
+
+# Ant Control in Pottsville – Eco-Friendly & Licensed
+
+We deliver ant control across Pottsville. Our licensed techs use low-tox
+products that keep families, pets and the coast safe. Call 0405 508 035 for fast
+help or a quote today.
+
+**Call 0405 508 035**
+
+## Why choose us
+
+- Local technicians based near the Tweed Coast
+- Low-tox methods safe for kids and pets
+- Clear pricing and written reports
+
+## What’s included / excluded
+
+Includes: onsite assessment, targeted ant control and follow-up advice. Excludes: snakes, mammals, birds or reptiles.
+
+## Pricing & timing
+
+Ant treatments in Pottsville start from $220 and are usually wrapped up within an hour.
+
+## Our process
+
+1. Call or book online to schedule a visit.
+2. We inspect and identify the pests and entry points.
+3. We treat the problem with low-tox methods suited to your property.
+4. We provide a report and tips to keep pests away.
+
+## Local proof
+
+We’re based in Kingscliff and regularly service Pottsville and nearby spots like Cabarita and Murwillumbah.
+
+## Reviews
+
+> “Prompt and professional.” – Sarah M
+> “No more pests after one visit.” – Jake R
+
+## More help
+
+Need termite control? See our [Termite Control in Pottsville](/termite-control-pottsville/).
+
+Looking for termite inspections? Check out [Termite Inspections in Pottsville](/termite-inspections-pottsville/).
+
+Ready for ant control? **Call 0405 508 035**.

--- a/content/cockroach-control-cabarita.md
+++ b/content/cockroach-control-cabarita.md
@@ -1,0 +1,69 @@
++++
+title = "Cockroach Control Cabarita | Eco-Friendly & Licensed | Local Pest Co"
+meta_desc = "Local, low-tox cockroach control in Cabarita. Licensed techs, fast call-outs, clear pricing. Book today: 0405 508 035."
+[service]
+serviceType = "Cockroach Control"
+areaServed = "Cabarita"
+priceRange = "$220 with follow-up if needed in two weeks."
+[[faq]]
+question = "Do you remove snakes?"
+answer = "We don’t remove snakes. For safety, please contact a licensed snake catcher. If a snake is inside, keep clear and close interior doors until help arrives."
+[[faq]]
+question = "Do you handle mammals like possums, rats, or mice?"
+answer = "We don’t handle mammals. We focus on termites and small insects. Please contact licensed wildlife or rodent specialists for these."
+[[faq]]
+question = "Do you remove birds or bats?"
+answer = "We don’t manage birds or bats. Seek licensed wildlife handlers and follow NSW regulations."
+[[faq]]
+question = "How quickly do cockroach treatments work?"
+answer = "You’ll see results within a day, with full control in about a week as baits take effect."
+[[faq]]
+question = "Do you treat German cockroaches?"
+answer = "Yes, our targeted gels knock down German cockroaches hiding in kitchens and appliances."
++++
+
+# Cockroach Control in Cabarita – Eco-Friendly & Licensed
+
+We deliver cockroach control across Cabarita. Our licensed techs use low-tox
+products that keep families, pets and the coast safe. Call 0405 508 035 for fast
+help or a quote today.
+
+**Call 0405 508 035**
+
+## Why choose us
+
+- Local technicians based near the Tweed Coast
+- Low-tox methods safe for kids and pets
+- Clear pricing and written reports
+
+## What’s included / excluded
+
+Includes: onsite assessment, targeted cockroach control and follow-up advice. Excludes: snakes, mammals, birds or reptiles.
+
+## Pricing & timing
+
+Cockroach treatments in Cabarita start from $220 with follow-up if needed in two weeks.
+
+## Our process
+
+1. Call or book online to schedule a visit.
+2. We inspect and identify the pests and entry points.
+3. We treat the problem with low-tox methods suited to your property.
+4. We provide a report and tips to keep pests away.
+
+## Local proof
+
+We’re based in Kingscliff and regularly service Cabarita and nearby spots like Murwillumbah and Chinderah.
+
+## Reviews
+
+> “Prompt and professional.” – Sarah M
+> “No more pests after one visit.” – Jake R
+
+## More help
+
+Need termite control? See our [Termite Control in Cabarita](/termite-control-cabarita/).
+
+Looking for termite inspections? Check out [Termite Inspections in Cabarita](/termite-inspections-cabarita/).
+
+Ready for cockroach control? **Call 0405 508 035**.

--- a/content/cockroach-control-casuarina.md
+++ b/content/cockroach-control-casuarina.md
@@ -1,0 +1,69 @@
++++
+title = "Cockroach Control Casuarina | Eco-Friendly & Licensed | Local Pest Co"
+meta_desc = "Local, low-tox cockroach control in Casuarina. Licensed techs, fast call-outs, clear pricing. Book today: 0405 508 035."
+[service]
+serviceType = "Cockroach Control"
+areaServed = "Casuarina"
+priceRange = "$220 with follow-up if needed in two weeks."
+[[faq]]
+question = "Do you remove snakes?"
+answer = "We don’t remove snakes. For safety, please contact a licensed snake catcher. If a snake is inside, keep clear and close interior doors until help arrives."
+[[faq]]
+question = "Do you handle mammals like possums, rats, or mice?"
+answer = "We don’t handle mammals. We focus on termites and small insects. Please contact licensed wildlife or rodent specialists for these."
+[[faq]]
+question = "Do you remove birds or bats?"
+answer = "We don’t manage birds or bats. Seek licensed wildlife handlers and follow NSW regulations."
+[[faq]]
+question = "How quickly do cockroach treatments work?"
+answer = "You’ll see results within a day, with full control in about a week as baits take effect."
+[[faq]]
+question = "Do you treat German cockroaches?"
+answer = "Yes, our targeted gels knock down German cockroaches hiding in kitchens and appliances."
++++
+
+# Cockroach Control in Casuarina – Eco-Friendly & Licensed
+
+We deliver cockroach control across Casuarina. Our licensed techs use low-tox
+products that keep families, pets and the coast safe. Call 0405 508 035 for fast
+help or a quote today.
+
+**Call 0405 508 035**
+
+## Why choose us
+
+- Local technicians based near the Tweed Coast
+- Low-tox methods safe for kids and pets
+- Clear pricing and written reports
+
+## What’s included / excluded
+
+Includes: onsite assessment, targeted cockroach control and follow-up advice. Excludes: snakes, mammals, birds or reptiles.
+
+## Pricing & timing
+
+Cockroach treatments in Casuarina start from $220 with follow-up if needed in two weeks.
+
+## Our process
+
+1. Call or book online to schedule a visit.
+2. We inspect and identify the pests and entry points.
+3. We treat the problem with low-tox methods suited to your property.
+4. We provide a report and tips to keep pests away.
+
+## Local proof
+
+We’re based in Kingscliff and regularly service Casuarina and nearby spots like Pottsville and Cabarita.
+
+## Reviews
+
+> “Prompt and professional.” – Sarah M
+> “No more pests after one visit.” – Jake R
+
+## More help
+
+Need termite control? See our [Termite Control in Casuarina](/termite-control-casuarina/).
+
+Looking for termite inspections? Check out [Termite Inspections in Casuarina](/termite-inspections-casuarina/).
+
+Ready for cockroach control? **Call 0405 508 035**.

--- a/content/cockroach-control-chinderah.md
+++ b/content/cockroach-control-chinderah.md
@@ -1,0 +1,69 @@
++++
+title = "Cockroach Control Chinderah | Eco-Friendly & Licensed | Local Pest Co"
+meta_desc = "Local, low-tox cockroach control in Chinderah. Licensed techs, fast call-outs, clear pricing. Book today: 0405 508 035."
+[service]
+serviceType = "Cockroach Control"
+areaServed = "Chinderah"
+priceRange = "$220 with follow-up if needed in two weeks."
+[[faq]]
+question = "Do you remove snakes?"
+answer = "We don’t remove snakes. For safety, please contact a licensed snake catcher. If a snake is inside, keep clear and close interior doors until help arrives."
+[[faq]]
+question = "Do you handle mammals like possums, rats, or mice?"
+answer = "We don’t handle mammals. We focus on termites and small insects. Please contact licensed wildlife or rodent specialists for these."
+[[faq]]
+question = "Do you remove birds or bats?"
+answer = "We don’t manage birds or bats. Seek licensed wildlife handlers and follow NSW regulations."
+[[faq]]
+question = "How quickly do cockroach treatments work?"
+answer = "You’ll see results within a day, with full control in about a week as baits take effect."
+[[faq]]
+question = "Do you treat German cockroaches?"
+answer = "Yes, our targeted gels knock down German cockroaches hiding in kitchens and appliances."
++++
+
+# Cockroach Control in Chinderah – Eco-Friendly & Licensed
+
+We deliver cockroach control across Chinderah. Our licensed techs use low-tox
+products that keep families, pets and the coast safe. Call 0405 508 035 for fast
+help or a quote today.
+
+**Call 0405 508 035**
+
+## Why choose us
+
+- Local technicians based near the Tweed Coast
+- Low-tox methods safe for kids and pets
+- Clear pricing and written reports
+
+## What’s included / excluded
+
+Includes: onsite assessment, targeted cockroach control and follow-up advice. Excludes: snakes, mammals, birds or reptiles.
+
+## Pricing & timing
+
+Cockroach treatments in Chinderah start from $220 with follow-up if needed in two weeks.
+
+## Our process
+
+1. Call or book online to schedule a visit.
+2. We inspect and identify the pests and entry points.
+3. We treat the problem with low-tox methods suited to your property.
+4. We provide a report and tips to keep pests away.
+
+## Local proof
+
+We’re based in Kingscliff and regularly service Chinderah and nearby spots like Cudgen and Casuarina.
+
+## Reviews
+
+> “Prompt and professional.” – Sarah M
+> “No more pests after one visit.” – Jake R
+
+## More help
+
+Need termite control? See our [Termite Control in Chinderah](/termite-control-chinderah/).
+
+Looking for termite inspections? Check out [Termite Inspections in Chinderah](/termite-inspections-chinderah/).
+
+Ready for cockroach control? **Call 0405 508 035**.

--- a/content/cockroach-control-cudgen.md
+++ b/content/cockroach-control-cudgen.md
@@ -1,0 +1,69 @@
++++
+title = "Cockroach Control Cudgen | Eco-Friendly & Licensed | Local Pest Co"
+meta_desc = "Local, low-tox cockroach control in Cudgen. Licensed techs, fast call-outs, clear pricing. Book today: 0405 508 035."
+[service]
+serviceType = "Cockroach Control"
+areaServed = "Cudgen"
+priceRange = "$220 with follow-up if needed in two weeks."
+[[faq]]
+question = "Do you remove snakes?"
+answer = "We don’t remove snakes. For safety, please contact a licensed snake catcher. If a snake is inside, keep clear and close interior doors until help arrives."
+[[faq]]
+question = "Do you handle mammals like possums, rats, or mice?"
+answer = "We don’t handle mammals. We focus on termites and small insects. Please contact licensed wildlife or rodent specialists for these."
+[[faq]]
+question = "Do you remove birds or bats?"
+answer = "We don’t manage birds or bats. Seek licensed wildlife handlers and follow NSW regulations."
+[[faq]]
+question = "How quickly do cockroach treatments work?"
+answer = "You’ll see results within a day, with full control in about a week as baits take effect."
+[[faq]]
+question = "Do you treat German cockroaches?"
+answer = "Yes, our targeted gels knock down German cockroaches hiding in kitchens and appliances."
++++
+
+# Cockroach Control in Cudgen – Eco-Friendly & Licensed
+
+We deliver cockroach control across Cudgen. Our licensed techs use low-tox
+products that keep families, pets and the coast safe. Call 0405 508 035 for fast
+help or a quote today.
+
+**Call 0405 508 035**
+
+## Why choose us
+
+- Local technicians based near the Tweed Coast
+- Low-tox methods safe for kids and pets
+- Clear pricing and written reports
+
+## What’s included / excluded
+
+Includes: onsite assessment, targeted cockroach control and follow-up advice. Excludes: snakes, mammals, birds or reptiles.
+
+## Pricing & timing
+
+Cockroach treatments in Cudgen start from $220 with follow-up if needed in two weeks.
+
+## Our process
+
+1. Call or book online to schedule a visit.
+2. We inspect and identify the pests and entry points.
+3. We treat the problem with low-tox methods suited to your property.
+4. We provide a report and tips to keep pests away.
+
+## Local proof
+
+We’re based in Kingscliff and regularly service Cudgen and nearby spots like Casuarina and Pottsville.
+
+## Reviews
+
+> “Prompt and professional.” – Sarah M
+> “No more pests after one visit.” – Jake R
+
+## More help
+
+Need termite control? See our [Termite Control in Cudgen](/termite-control-cudgen/).
+
+Looking for termite inspections? Check out [Termite Inspections in Cudgen](/termite-inspections-cudgen/).
+
+Ready for cockroach control? **Call 0405 508 035**.

--- a/content/cockroach-control-murwillumbah.md
+++ b/content/cockroach-control-murwillumbah.md
@@ -1,0 +1,69 @@
++++
+title = "Cockroach Control Murwillumbah | Eco-Friendly & Licensed | Local Pest Co"
+meta_desc = "Local, low-tox cockroach control in Murwillumbah. Licensed techs, fast call-outs, clear pricing. Book today: 0405 508 035."
+[service]
+serviceType = "Cockroach Control"
+areaServed = "Murwillumbah"
+priceRange = "$220 with follow-up if needed in two weeks."
+[[faq]]
+question = "Do you remove snakes?"
+answer = "We don’t remove snakes. For safety, please contact a licensed snake catcher. If a snake is inside, keep clear and close interior doors until help arrives."
+[[faq]]
+question = "Do you handle mammals like possums, rats, or mice?"
+answer = "We don’t handle mammals. We focus on termites and small insects. Please contact licensed wildlife or rodent specialists for these."
+[[faq]]
+question = "Do you remove birds or bats?"
+answer = "We don’t manage birds or bats. Seek licensed wildlife handlers and follow NSW regulations."
+[[faq]]
+question = "How quickly do cockroach treatments work?"
+answer = "You’ll see results within a day, with full control in about a week as baits take effect."
+[[faq]]
+question = "Do you treat German cockroaches?"
+answer = "Yes, our targeted gels knock down German cockroaches hiding in kitchens and appliances."
++++
+
+# Cockroach Control in Murwillumbah – Eco-Friendly & Licensed
+
+We deliver cockroach control across Murwillumbah. Our licensed techs use low-tox
+products that keep families, pets and the coast safe. Call 0405 508 035 for fast
+help or a quote today.
+
+**Call 0405 508 035**
+
+## Why choose us
+
+- Local technicians based near the Tweed Coast
+- Low-tox methods safe for kids and pets
+- Clear pricing and written reports
+
+## What’s included / excluded
+
+Includes: onsite assessment, targeted cockroach control and follow-up advice. Excludes: snakes, mammals, birds or reptiles.
+
+## Pricing & timing
+
+Cockroach treatments in Murwillumbah start from $220 with follow-up if needed in two weeks.
+
+## Our process
+
+1. Call or book online to schedule a visit.
+2. We inspect and identify the pests and entry points.
+3. We treat the problem with low-tox methods suited to your property.
+4. We provide a report and tips to keep pests away.
+
+## Local proof
+
+We’re based in Kingscliff and regularly service Murwillumbah and nearby spots like Chinderah and Cudgen.
+
+## Reviews
+
+> “Prompt and professional.” – Sarah M
+> “No more pests after one visit.” – Jake R
+
+## More help
+
+Need termite control? See our [Termite Control in Murwillumbah](/termite-control-murwillumbah/).
+
+Looking for termite inspections? Check out [Termite Inspections in Murwillumbah](/termite-inspections-murwillumbah/).
+
+Ready for cockroach control? **Call 0405 508 035**.

--- a/content/cockroach-control-pottsville.md
+++ b/content/cockroach-control-pottsville.md
@@ -1,0 +1,69 @@
++++
+title = "Cockroach Control Pottsville | Eco-Friendly & Licensed | Local Pest Co"
+meta_desc = "Local, low-tox cockroach control in Pottsville. Licensed techs, fast call-outs, clear pricing. Book today: 0405 508 035."
+[service]
+serviceType = "Cockroach Control"
+areaServed = "Pottsville"
+priceRange = "$220 with follow-up if needed in two weeks."
+[[faq]]
+question = "Do you remove snakes?"
+answer = "We don’t remove snakes. For safety, please contact a licensed snake catcher. If a snake is inside, keep clear and close interior doors until help arrives."
+[[faq]]
+question = "Do you handle mammals like possums, rats, or mice?"
+answer = "We don’t handle mammals. We focus on termites and small insects. Please contact licensed wildlife or rodent specialists for these."
+[[faq]]
+question = "Do you remove birds or bats?"
+answer = "We don’t manage birds or bats. Seek licensed wildlife handlers and follow NSW regulations."
+[[faq]]
+question = "How quickly do cockroach treatments work?"
+answer = "You’ll see results within a day, with full control in about a week as baits take effect."
+[[faq]]
+question = "Do you treat German cockroaches?"
+answer = "Yes, our targeted gels knock down German cockroaches hiding in kitchens and appliances."
++++
+
+# Cockroach Control in Pottsville – Eco-Friendly & Licensed
+
+We deliver cockroach control across Pottsville. Our licensed techs use low-tox
+products that keep families, pets and the coast safe. Call 0405 508 035 for fast
+help or a quote today.
+
+**Call 0405 508 035**
+
+## Why choose us
+
+- Local technicians based near the Tweed Coast
+- Low-tox methods safe for kids and pets
+- Clear pricing and written reports
+
+## What’s included / excluded
+
+Includes: onsite assessment, targeted cockroach control and follow-up advice. Excludes: snakes, mammals, birds or reptiles.
+
+## Pricing & timing
+
+Cockroach treatments in Pottsville start from $220 with follow-up if needed in two weeks.
+
+## Our process
+
+1. Call or book online to schedule a visit.
+2. We inspect and identify the pests and entry points.
+3. We treat the problem with low-tox methods suited to your property.
+4. We provide a report and tips to keep pests away.
+
+## Local proof
+
+We’re based in Kingscliff and regularly service Pottsville and nearby spots like Cabarita and Murwillumbah.
+
+## Reviews
+
+> “Prompt and professional.” – Sarah M
+> “No more pests after one visit.” – Jake R
+
+## More help
+
+Need termite control? See our [Termite Control in Pottsville](/termite-control-pottsville/).
+
+Looking for termite inspections? Check out [Termite Inspections in Pottsville](/termite-inspections-pottsville/).
+
+Ready for cockroach control? **Call 0405 508 035**.

--- a/content/pest-control-kingscliff.md
+++ b/content/pest-control-kingscliff.md
@@ -1,0 +1,76 @@
++++
+title = "Pest Control Kingscliff | Eco-Friendly & Licensed | Local Pest Co"
+meta_desc = "Local, low-tox pest control in Kingscliff. Licensed techs, fast call-outs, clear pricing. Book today: 0405 508 035."
+[service]
+serviceType = "Pest Control"
+areaServed = "Kingscliff"
+priceRange = "from $220"
+faq_id = "we-dont-do"
+[[faq]]
+question = "Do you remove snakes?"
+answer = "We don’t remove snakes. For safety, please contact a licensed snake catcher. If a snake is inside, keep clear and close interior doors until help arrives."
+[[faq]]
+question = "Do you handle mammals like possums, rats, or mice?"
+answer = "We don’t handle mammals. We focus on termites and small insects. Please contact licensed wildlife or rodent specialists for these."
+[[faq]]
+question = "Do you remove birds or bats?"
+answer = "We don’t manage birds or bats. Seek licensed wildlife handlers and follow NSW regulations."
+[[faq]]
+question = "How quickly can you attend in Kingscliff?"
+answer = "Most call-outs in Kingscliff are booked within two business days, often sooner for urgent jobs."
+[[faq]]
+question = "Are your products safe for pets and kids?"
+answer = "Yes, we favour low-tox gels, baits and sprays that are safe once dry. We explain any precautions before we start."
++++
+
+# Pest Control in Kingscliff – Eco-Friendly & Licensed
+
+We protect Kingscliff homes with eco-friendly treatments for termites and small insects. Our local team uses low-tox products and clear communication so you know exactly what’s happening. Call 0405 508 035 to book a service or quote.
+
+**Call 0405 508 035**
+
+## Why choose us
+
+- Local family team based in Kingscliff
+- Low-tox methods that respect our coast
+- Digital reports and clear pricing
+- Friendly techs with NSW licences
+
+## Service overview
+
+We handle termites, ants, cockroaches, spiders, wasps, fleas, bed bugs and silverfish. For termite advice see our [Termite Control Guide](/termite-control-guide/) or book a [Pre-Purchase Termite Inspection](/pre-purchase-termite-inspections-kingscliff/).
+
+## Pricing & timing
+
+General pest treatments in Kingscliff start from $220 and usually take under two hours. Termite work such as baiting or barriers starts from $1,100. We provide written quotes before we begin.
+
+## Our process
+
+1. Call or email to book.
+2. We inspect and identify the pest issues.
+3. We treat using low-tox methods suited to your property.
+4. We provide a report and schedule follow-up if needed.
+
+## Areas we serve
+
+We’re based in Kingscliff and service the Tweed Coast including:
+
+- [Casuarina termite control](/termite-control-casuarina/)
+- [Cabarita termite control](/termite-control-cabarita/)
+- [Pottsville termite control](/termite-control-pottsville/)
+- [Murwillumbah termite control](/termite-control-murwillumbah/)
+- [Chinderah termite control](/termite-control-chinderah/)
+- [Cudgen termite control](/termite-control-cudgen/)
+
+## Reviews
+
+> “Reliable and thorough—our go-to for yearly inspections.” – Emma L
+> “Great communication and no more cockroaches.” – Tim S
+
+## FAQs
+
+The FAQ section below covers what we don’t do and common questions about our services.
+
+## Final call to action
+
+Ready for pest control in Kingscliff? **Call 0405 508 035** or [contact us](/contact/).

--- a/content/pre-purchase-termite-inspections-kingscliff.md
+++ b/content/pre-purchase-termite-inspections-kingscliff.md
@@ -1,0 +1,53 @@
++++
+title = "Pre-Purchase Termite Inspections Kingscliff | Eco-Friendly & Licensed | Local Pest Co"
+meta_desc = "Local, low-tox pre-purchase termite inspections in Kingscliff. Licensed techs, fast call-outs, clear pricing. Book today: 0405 508 035."
+[service]
+serviceType = "Pre-Purchase Termite Inspections"
+areaServed = "Kingscliff"
+priceRange = "from $330"
+[[faq]]
+question = "Do you remove snakes?"
+answer = "We don’t remove snakes. For safety, please contact a licensed snake catcher. If a snake is inside, keep clear and close interior doors until help arrives."
+[[faq]]
+question = "Do you handle mammals like possums, rats, or mice?"
+answer = "We don’t handle mammals. We focus on termites and small insects. Please contact licensed wildlife or rodent specialists for these."
+[[faq]]
+question = "Do you remove birds or bats?"
+answer = "We don’t manage birds or bats. Seek licensed wildlife handlers and follow NSW regulations."
+[[faq]]
+question = "How quickly can we get the report?"
+answer = "You’ll receive the digital report within 24 hours."
+[[faq]]
+question = "Do you inspect roofs and subfloors?"
+answer = "Yes, we access all safe areas including roofs and subfloors."
++++
+# Pre-Purchase Termite Inspections in Kingscliff – Eco-Friendly & Licensed
+
+We provide pre-purchase termite inspections in Kingscliff. Our licensed techs use low-tox methods that suit coastal homes.
+
+**Call 0405 508 035**
+
+## What’s included / excluded
+
+Inspections include a detailed timber pest report for buyers in Kingscliff. Excludes: snakes, mammals, birds or reptiles.
+
+## Pricing & timing
+
+Most pre-purchase inspections start from $330 and take around 90 minutes. Reports are delivered same day.
+
+## Our process
+
+1. Call or book online.
+2. We inspect and map termite risk.
+3. We install the system or conduct the inspection.
+4. We send a report and outline follow-up steps.
+
+## Local proof
+
+We’re based in Kingscliff and service Casuarina, Cabarita and Pottsville.
+
+## Reviews
+
+> “Reliable and informative.” – Alex P
+
+Ready to secure your place? **Call 0405 508 035**.

--- a/content/spider-control-cabarita.md
+++ b/content/spider-control-cabarita.md
@@ -1,0 +1,69 @@
++++
+title = "Spider Control Cabarita | Eco-Friendly & Licensed | Local Pest Co"
+meta_desc = "Local, low-tox spider control in Cabarita. Licensed techs, fast call-outs, clear pricing. Book today: 0405 508 035."
+[service]
+serviceType = "Spider Control"
+areaServed = "Cabarita"
+priceRange = "$220"
+[[faq]]
+question = "Do you remove snakes?"
+answer = "We don’t remove snakes. For safety, please contact a licensed snake catcher. If a snake is inside, keep clear and close interior doors until help arrives."
+[[faq]]
+question = "Do you handle mammals like possums, rats, or mice?"
+answer = "We don’t handle mammals. We focus on termites and small insects. Please contact licensed wildlife or rodent specialists for these."
+[[faq]]
+question = "Do you remove birds or bats?"
+answer = "We don’t manage birds or bats. Seek licensed wildlife handlers and follow NSW regulations."
+[[faq]]
+question = "Do you remove webbing?"
+answer = "We brush away accessible webbing as part of our service."
+[[faq]]
+question = "Is exterior spraying necessary?"
+answer = "Exterior treatments create a barrier that keeps spiders from moving inside, so we include it where possible."
++++
+
+# Spider Control in Cabarita – Eco-Friendly & Licensed
+
+We deliver spider control across Cabarita. Our licensed techs use low-tox
+products that keep families, pets and the coast safe. Call 0405 508 035 for fast
+help or a quote today.
+
+**Call 0405 508 035**
+
+## Why choose us
+
+- Local technicians based near the Tweed Coast
+- Low-tox methods safe for kids and pets
+- Clear pricing and written reports
+
+## What’s included / excluded
+
+Includes: onsite assessment, targeted spider control and follow-up advice. Excludes: snakes, mammals, birds or reptiles.
+
+## Pricing & timing
+
+Spider treatments in Cabarita start from $220 and normally take around an hour.
+
+## Our process
+
+1. Call or book online to schedule a visit.
+2. We inspect and identify the pests and entry points.
+3. We treat the problem with low-tox methods suited to your property.
+4. We provide a report and tips to keep pests away.
+
+## Local proof
+
+We’re based in Kingscliff and regularly service Cabarita and nearby spots like Murwillumbah and Chinderah.
+
+## Reviews
+
+> “Prompt and professional.” – Sarah M
+> “No more pests after one visit.” – Jake R
+
+## More help
+
+Need termite control? See our [Termite Control in Cabarita](/termite-control-cabarita/).
+
+Looking for termite inspections? Check out [Termite Inspections in Cabarita](/termite-inspections-cabarita/).
+
+Ready for spider control? **Call 0405 508 035**.

--- a/content/spider-control-casuarina.md
+++ b/content/spider-control-casuarina.md
@@ -1,0 +1,69 @@
++++
+title = "Spider Control Casuarina | Eco-Friendly & Licensed | Local Pest Co"
+meta_desc = "Local, low-tox spider control in Casuarina. Licensed techs, fast call-outs, clear pricing. Book today: 0405 508 035."
+[service]
+serviceType = "Spider Control"
+areaServed = "Casuarina"
+priceRange = "$220"
+[[faq]]
+question = "Do you remove snakes?"
+answer = "We don’t remove snakes. For safety, please contact a licensed snake catcher. If a snake is inside, keep clear and close interior doors until help arrives."
+[[faq]]
+question = "Do you handle mammals like possums, rats, or mice?"
+answer = "We don’t handle mammals. We focus on termites and small insects. Please contact licensed wildlife or rodent specialists for these."
+[[faq]]
+question = "Do you remove birds or bats?"
+answer = "We don’t manage birds or bats. Seek licensed wildlife handlers and follow NSW regulations."
+[[faq]]
+question = "Do you remove webbing?"
+answer = "We brush away accessible webbing as part of our service."
+[[faq]]
+question = "Is exterior spraying necessary?"
+answer = "Exterior treatments create a barrier that keeps spiders from moving inside, so we include it where possible."
++++
+
+# Spider Control in Casuarina – Eco-Friendly & Licensed
+
+We deliver spider control across Casuarina. Our licensed techs use low-tox
+products that keep families, pets and the coast safe. Call 0405 508 035 for fast
+help or a quote today.
+
+**Call 0405 508 035**
+
+## Why choose us
+
+- Local technicians based near the Tweed Coast
+- Low-tox methods safe for kids and pets
+- Clear pricing and written reports
+
+## What’s included / excluded
+
+Includes: onsite assessment, targeted spider control and follow-up advice. Excludes: snakes, mammals, birds or reptiles.
+
+## Pricing & timing
+
+Spider treatments in Casuarina start from $220 and normally take around an hour.
+
+## Our process
+
+1. Call or book online to schedule a visit.
+2. We inspect and identify the pests and entry points.
+3. We treat the problem with low-tox methods suited to your property.
+4. We provide a report and tips to keep pests away.
+
+## Local proof
+
+We’re based in Kingscliff and regularly service Casuarina and nearby spots like Pottsville and Cabarita.
+
+## Reviews
+
+> “Prompt and professional.” – Sarah M
+> “No more pests after one visit.” – Jake R
+
+## More help
+
+Need termite control? See our [Termite Control in Casuarina](/termite-control-casuarina/).
+
+Looking for termite inspections? Check out [Termite Inspections in Casuarina](/termite-inspections-casuarina/).
+
+Ready for spider control? **Call 0405 508 035**.

--- a/content/spider-control-chinderah.md
+++ b/content/spider-control-chinderah.md
@@ -1,0 +1,69 @@
++++
+title = "Spider Control Chinderah | Eco-Friendly & Licensed | Local Pest Co"
+meta_desc = "Local, low-tox spider control in Chinderah. Licensed techs, fast call-outs, clear pricing. Book today: 0405 508 035."
+[service]
+serviceType = "Spider Control"
+areaServed = "Chinderah"
+priceRange = "$220"
+[[faq]]
+question = "Do you remove snakes?"
+answer = "We don’t remove snakes. For safety, please contact a licensed snake catcher. If a snake is inside, keep clear and close interior doors until help arrives."
+[[faq]]
+question = "Do you handle mammals like possums, rats, or mice?"
+answer = "We don’t handle mammals. We focus on termites and small insects. Please contact licensed wildlife or rodent specialists for these."
+[[faq]]
+question = "Do you remove birds or bats?"
+answer = "We don’t manage birds or bats. Seek licensed wildlife handlers and follow NSW regulations."
+[[faq]]
+question = "Do you remove webbing?"
+answer = "We brush away accessible webbing as part of our service."
+[[faq]]
+question = "Is exterior spraying necessary?"
+answer = "Exterior treatments create a barrier that keeps spiders from moving inside, so we include it where possible."
++++
+
+# Spider Control in Chinderah – Eco-Friendly & Licensed
+
+We deliver spider control across Chinderah. Our licensed techs use low-tox
+products that keep families, pets and the coast safe. Call 0405 508 035 for fast
+help or a quote today.
+
+**Call 0405 508 035**
+
+## Why choose us
+
+- Local technicians based near the Tweed Coast
+- Low-tox methods safe for kids and pets
+- Clear pricing and written reports
+
+## What’s included / excluded
+
+Includes: onsite assessment, targeted spider control and follow-up advice. Excludes: snakes, mammals, birds or reptiles.
+
+## Pricing & timing
+
+Spider treatments in Chinderah start from $220 and normally take around an hour.
+
+## Our process
+
+1. Call or book online to schedule a visit.
+2. We inspect and identify the pests and entry points.
+3. We treat the problem with low-tox methods suited to your property.
+4. We provide a report and tips to keep pests away.
+
+## Local proof
+
+We’re based in Kingscliff and regularly service Chinderah and nearby spots like Cudgen and Casuarina.
+
+## Reviews
+
+> “Prompt and professional.” – Sarah M
+> “No more pests after one visit.” – Jake R
+
+## More help
+
+Need termite control? See our [Termite Control in Chinderah](/termite-control-chinderah/).
+
+Looking for termite inspections? Check out [Termite Inspections in Chinderah](/termite-inspections-chinderah/).
+
+Ready for spider control? **Call 0405 508 035**.

--- a/content/spider-control-cudgen.md
+++ b/content/spider-control-cudgen.md
@@ -1,0 +1,69 @@
++++
+title = "Spider Control Cudgen | Eco-Friendly & Licensed | Local Pest Co"
+meta_desc = "Local, low-tox spider control in Cudgen. Licensed techs, fast call-outs, clear pricing. Book today: 0405 508 035."
+[service]
+serviceType = "Spider Control"
+areaServed = "Cudgen"
+priceRange = "$220"
+[[faq]]
+question = "Do you remove snakes?"
+answer = "We don’t remove snakes. For safety, please contact a licensed snake catcher. If a snake is inside, keep clear and close interior doors until help arrives."
+[[faq]]
+question = "Do you handle mammals like possums, rats, or mice?"
+answer = "We don’t handle mammals. We focus on termites and small insects. Please contact licensed wildlife or rodent specialists for these."
+[[faq]]
+question = "Do you remove birds or bats?"
+answer = "We don’t manage birds or bats. Seek licensed wildlife handlers and follow NSW regulations."
+[[faq]]
+question = "Do you remove webbing?"
+answer = "We brush away accessible webbing as part of our service."
+[[faq]]
+question = "Is exterior spraying necessary?"
+answer = "Exterior treatments create a barrier that keeps spiders from moving inside, so we include it where possible."
++++
+
+# Spider Control in Cudgen – Eco-Friendly & Licensed
+
+We deliver spider control across Cudgen. Our licensed techs use low-tox products
+that keep families, pets and the coast safe. Call 0405 508 035 for fast help or
+a quote today.
+
+**Call 0405 508 035**
+
+## Why choose us
+
+- Local technicians based near the Tweed Coast
+- Low-tox methods safe for kids and pets
+- Clear pricing and written reports
+
+## What’s included / excluded
+
+Includes: onsite assessment, targeted spider control and follow-up advice. Excludes: snakes, mammals, birds or reptiles.
+
+## Pricing & timing
+
+Spider treatments in Cudgen start from $220 and normally take around an hour.
+
+## Our process
+
+1. Call or book online to schedule a visit.
+2. We inspect and identify the pests and entry points.
+3. We treat the problem with low-tox methods suited to your property.
+4. We provide a report and tips to keep pests away.
+
+## Local proof
+
+We’re based in Kingscliff and regularly service Cudgen and nearby spots like Casuarina and Pottsville.
+
+## Reviews
+
+> “Prompt and professional.” – Sarah M
+> “No more pests after one visit.” – Jake R
+
+## More help
+
+Need termite control? See our [Termite Control in Cudgen](/termite-control-cudgen/).
+
+Looking for termite inspections? Check out [Termite Inspections in Cudgen](/termite-inspections-cudgen/).
+
+Ready for spider control? **Call 0405 508 035**.

--- a/content/spider-control-murwillumbah.md
+++ b/content/spider-control-murwillumbah.md
@@ -1,0 +1,69 @@
++++
+title = "Spider Control Murwillumbah | Eco-Friendly & Licensed | Local Pest Co"
+meta_desc = "Local, low-tox spider control in Murwillumbah. Licensed techs, fast call-outs, clear pricing. Book today: 0405 508 035."
+[service]
+serviceType = "Spider Control"
+areaServed = "Murwillumbah"
+priceRange = "$220"
+[[faq]]
+question = "Do you remove snakes?"
+answer = "We don’t remove snakes. For safety, please contact a licensed snake catcher. If a snake is inside, keep clear and close interior doors until help arrives."
+[[faq]]
+question = "Do you handle mammals like possums, rats, or mice?"
+answer = "We don’t handle mammals. We focus on termites and small insects. Please contact licensed wildlife or rodent specialists for these."
+[[faq]]
+question = "Do you remove birds or bats?"
+answer = "We don’t manage birds or bats. Seek licensed wildlife handlers and follow NSW regulations."
+[[faq]]
+question = "Do you remove webbing?"
+answer = "We brush away accessible webbing as part of our service."
+[[faq]]
+question = "Is exterior spraying necessary?"
+answer = "Exterior treatments create a barrier that keeps spiders from moving inside, so we include it where possible."
++++
+
+# Spider Control in Murwillumbah – Eco-Friendly & Licensed
+
+We deliver spider control across Murwillumbah. Our licensed techs use low-tox
+products that keep families, pets and the coast safe. Call 0405 508 035 for fast
+help or a quote today.
+
+**Call 0405 508 035**
+
+## Why choose us
+
+- Local technicians based near the Tweed Coast
+- Low-tox methods safe for kids and pets
+- Clear pricing and written reports
+
+## What’s included / excluded
+
+Includes: onsite assessment, targeted spider control and follow-up advice. Excludes: snakes, mammals, birds or reptiles.
+
+## Pricing & timing
+
+Spider treatments in Murwillumbah start from $220 and normally take around an hour.
+
+## Our process
+
+1. Call or book online to schedule a visit.
+2. We inspect and identify the pests and entry points.
+3. We treat the problem with low-tox methods suited to your property.
+4. We provide a report and tips to keep pests away.
+
+## Local proof
+
+We’re based in Kingscliff and regularly service Murwillumbah and nearby spots like Chinderah and Cudgen.
+
+## Reviews
+
+> “Prompt and professional.” – Sarah M
+> “No more pests after one visit.” – Jake R
+
+## More help
+
+Need termite control? See our [Termite Control in Murwillumbah](/termite-control-murwillumbah/).
+
+Looking for termite inspections? Check out [Termite Inspections in Murwillumbah](/termite-inspections-murwillumbah/).
+
+Ready for spider control? **Call 0405 508 035**.

--- a/content/spider-control-pottsville.md
+++ b/content/spider-control-pottsville.md
@@ -1,0 +1,69 @@
++++
+title = "Spider Control Pottsville | Eco-Friendly & Licensed | Local Pest Co"
+meta_desc = "Local, low-tox spider control in Pottsville. Licensed techs, fast call-outs, clear pricing. Book today: 0405 508 035."
+[service]
+serviceType = "Spider Control"
+areaServed = "Pottsville"
+priceRange = "$220"
+[[faq]]
+question = "Do you remove snakes?"
+answer = "We don’t remove snakes. For safety, please contact a licensed snake catcher. If a snake is inside, keep clear and close interior doors until help arrives."
+[[faq]]
+question = "Do you handle mammals like possums, rats, or mice?"
+answer = "We don’t handle mammals. We focus on termites and small insects. Please contact licensed wildlife or rodent specialists for these."
+[[faq]]
+question = "Do you remove birds or bats?"
+answer = "We don’t manage birds or bats. Seek licensed wildlife handlers and follow NSW regulations."
+[[faq]]
+question = "Do you remove webbing?"
+answer = "We brush away accessible webbing as part of our service."
+[[faq]]
+question = "Is exterior spraying necessary?"
+answer = "Exterior treatments create a barrier that keeps spiders from moving inside, so we include it where possible."
++++
+
+# Spider Control in Pottsville – Eco-Friendly & Licensed
+
+We deliver spider control across Pottsville. Our licensed techs use low-tox
+products that keep families, pets and the coast safe. Call 0405 508 035 for fast
+help or a quote today.
+
+**Call 0405 508 035**
+
+## Why choose us
+
+- Local technicians based near the Tweed Coast
+- Low-tox methods safe for kids and pets
+- Clear pricing and written reports
+
+## What’s included / excluded
+
+Includes: onsite assessment, targeted spider control and follow-up advice. Excludes: snakes, mammals, birds or reptiles.
+
+## Pricing & timing
+
+Spider treatments in Pottsville start from $220 and normally take around an hour.
+
+## Our process
+
+1. Call or book online to schedule a visit.
+2. We inspect and identify the pests and entry points.
+3. We treat the problem with low-tox methods suited to your property.
+4. We provide a report and tips to keep pests away.
+
+## Local proof
+
+We’re based in Kingscliff and regularly service Pottsville and nearby spots like Cabarita and Murwillumbah.
+
+## Reviews
+
+> “Prompt and professional.” – Sarah M
+> “No more pests after one visit.” – Jake R
+
+## More help
+
+Need termite control? See our [Termite Control in Pottsville](/termite-control-pottsville/).
+
+Looking for termite inspections? Check out [Termite Inspections in Pottsville](/termite-inspections-pottsville/).
+
+Ready for spider control? **Call 0405 508 035**.

--- a/content/termite-baiting-systems-kingscliff.md
+++ b/content/termite-baiting-systems-kingscliff.md
@@ -1,0 +1,53 @@
++++
+title = "Termite Baiting Systems Kingscliff | Eco-Friendly & Licensed | Local Pest Co"
+meta_desc = "Local, low-tox termite baiting systems in Kingscliff. Licensed techs, fast call-outs, clear pricing. Book today: 0405 508 035."
+[service]
+serviceType = "Termite Baiting Systems"
+areaServed = "Kingscliff"
+priceRange = "from $330"
+[[faq]]
+question = "Do you remove snakes?"
+answer = "We don’t remove snakes. For safety, please contact a licensed snake catcher. If a snake is inside, keep clear and close interior doors until help arrives."
+[[faq]]
+question = "Do you handle mammals like possums, rats, or mice?"
+answer = "We don’t handle mammals. We focus on termites and small insects. Please contact licensed wildlife or rodent specialists for these."
+[[faq]]
+question = "Do you remove birds or bats?"
+answer = "We don’t manage birds or bats. Seek licensed wildlife handlers and follow NSW regulations."
+[[faq]]
+question = "How often do you check the stations?"
+answer = "We visit every 8–12 weeks to refresh bait and record activity."
+[[faq]]
+question = "Are baiting systems pet-safe?"
+answer = "Yes, stations are locked and use low-tox bait that’s safe for pets and wildlife."
++++
+# Termite Baiting Systems in Kingscliff – Eco-Friendly & Licensed
+
+We provide termite baiting systems in Kingscliff. Our licensed techs use low-tox methods that suit coastal homes.
+
+**Call 0405 508 035**
+
+## What’s included / excluded
+
+We install and monitor bait stations around your home to eliminate colonies. Excludes: snakes, mammals, birds or reptiles.
+
+## Pricing & timing
+
+Baiting programs in Kingscliff start from $2,200 for a 12-month plan.
+
+## Our process
+
+1. Call or book online.
+2. We inspect and map termite risk.
+3. We install the system or conduct the inspection.
+4. We send a report and outline follow-up steps.
+
+## Local proof
+
+We’re based in Kingscliff and service Casuarina, Cabarita and Pottsville.
+
+## Reviews
+
+> “Reliable and informative.” – Alex P
+
+Ready to secure your place? **Call 0405 508 035**.

--- a/content/termite-barriers-kingscliff.md
+++ b/content/termite-barriers-kingscliff.md
@@ -1,0 +1,53 @@
++++
+title = "Termite Barriers Kingscliff | Eco-Friendly & Licensed | Local Pest Co"
+meta_desc = "Local, low-tox termite barriers in Kingscliff. Licensed techs, fast call-outs, clear pricing. Book today: 0405 508 035."
+[service]
+serviceType = "Termite Barriers"
+areaServed = "Kingscliff"
+priceRange = "from $330"
+[[faq]]
+question = "Do you remove snakes?"
+answer = "We don’t remove snakes. For safety, please contact a licensed snake catcher. If a snake is inside, keep clear and close interior doors until help arrives."
+[[faq]]
+question = "Do you handle mammals like possums, rats, or mice?"
+answer = "We don’t handle mammals. We focus on termites and small insects. Please contact licensed wildlife or rodent specialists for these."
+[[faq]]
+question = "Do you remove birds or bats?"
+answer = "We don’t manage birds or bats. Seek licensed wildlife handlers and follow NSW regulations."
+[[faq]]
+question = "How long does a barrier last?"
+answer = "Chemical barriers last up to eight years when maintained."
+[[faq]]
+question = "Will you need to drill through paths?"
+answer = "We drill and plug through concrete or pavers to maintain a full treated zone."
++++
+# Termite Barriers in Kingscliff – Eco-Friendly & Licensed
+
+We provide termite barriers in Kingscliff. Our licensed techs use low-tox methods that suit coastal homes.
+
+**Call 0405 508 035**
+
+## What’s included / excluded
+
+Our team trenches and treats soil to form a continuous chemical zone around your home. Excludes: snakes, mammals, birds or reptiles.
+
+## Pricing & timing
+
+Barrier installations around Kingscliff start from $3,500 and include an 8-year warranty with annual inspections.
+
+## Our process
+
+1. Call or book online.
+2. We inspect and map termite risk.
+3. We install the system or conduct the inspection.
+4. We send a report and outline follow-up steps.
+
+## Local proof
+
+We’re based in Kingscliff and service Casuarina, Cabarita and Pottsville.
+
+## Reviews
+
+> “Reliable and informative.” – Alex P
+
+Ready to secure your place? **Call 0405 508 035**.

--- a/content/termite-control-cabarita.md
+++ b/content/termite-control-cabarita.md
@@ -1,0 +1,69 @@
++++
+title = "Termite Control Cabarita | Eco-Friendly & Licensed | Local Pest Co"
+meta_desc = "Local, low-tox termite control in Cabarita. Licensed techs, fast call-outs, clear pricing. Book today: 0405 508 035."
+[service]
+serviceType = "Termite Control"
+areaServed = "Cabarita"
+priceRange = "$1,100"
+[[faq]]
+question = "Do you remove snakes?"
+answer = "We don’t remove snakes. For safety, please contact a licensed snake catcher. If a snake is inside, keep clear and close interior doors until help arrives."
+[[faq]]
+question = "Do you handle mammals like possums, rats, or mice?"
+answer = "We don’t handle mammals. We focus on termites and small insects. Please contact licensed wildlife or rodent specialists for these."
+[[faq]]
+question = "Do you remove birds or bats?"
+answer = "We don’t manage birds or bats. Seek licensed wildlife handlers and follow NSW regulations."
+[[faq]]
+question = "How often should we book termite inspections?"
+answer = "We suggest annual inspections in Cabarita to catch activity early."
+[[faq]]
+question = "Is baiting or a barrier better?"
+answer = "We recommend the option that suits the construction and soil at your place; we explain both on site."
++++
+
+# Termite Control in Cabarita – Eco-Friendly & Licensed
+
+We deliver termite control across Cabarita. Our licensed techs use low-tox
+products that keep families, pets and the coast safe. Call 0405 508 035 for fast
+help or a quote today.
+
+**Call 0405 508 035**
+
+## Why choose us
+
+- Local technicians based near the Tweed Coast
+- Low-tox methods safe for kids and pets
+- Clear pricing and written reports
+
+## What’s included / excluded
+
+Includes: onsite assessment, targeted termite control and follow-up advice. Excludes: snakes, mammals, birds or reptiles.
+
+## Pricing & timing
+
+Most termite treatments in Cabarita start from $1,100 and take 1–2 days. Monitoring plans from $30 per station each quarter.
+
+## Our process
+
+1. Call or book online to schedule a visit.
+2. We inspect and identify the pests and entry points.
+3. We treat the problem with low-tox methods suited to your property.
+4. We provide a report and tips to keep pests away.
+
+## Local proof
+
+We’re based in Kingscliff and regularly service Cabarita and nearby spots like Murwillumbah and Chinderah.
+
+## Reviews
+
+> “Prompt and professional.” – Sarah M
+> “No more pests after one visit.” – Jake R
+
+## More help
+
+Need termite inspections? See our [Termite Inspections in Cabarita](/termite-inspections-cabarita/).
+
+Looking for ant control? Check out [Ant Control in Cabarita](/ant-control-cabarita/).
+
+Ready for termite control? **Call 0405 508 035**.

--- a/content/termite-control-casuarina.md
+++ b/content/termite-control-casuarina.md
@@ -1,0 +1,69 @@
++++
+title = "Termite Control Casuarina | Eco-Friendly & Licensed | Local Pest Co"
+meta_desc = "Local, low-tox termite control in Casuarina. Licensed techs, fast call-outs, clear pricing. Book today: 0405 508 035."
+[service]
+serviceType = "Termite Control"
+areaServed = "Casuarina"
+priceRange = "$1,100"
+[[faq]]
+question = "Do you remove snakes?"
+answer = "We don’t remove snakes. For safety, please contact a licensed snake catcher. If a snake is inside, keep clear and close interior doors until help arrives."
+[[faq]]
+question = "Do you handle mammals like possums, rats, or mice?"
+answer = "We don’t handle mammals. We focus on termites and small insects. Please contact licensed wildlife or rodent specialists for these."
+[[faq]]
+question = "Do you remove birds or bats?"
+answer = "We don’t manage birds or bats. Seek licensed wildlife handlers and follow NSW regulations."
+[[faq]]
+question = "How often should we book termite inspections?"
+answer = "We suggest annual inspections in Casuarina to catch activity early."
+[[faq]]
+question = "Is baiting or a barrier better?"
+answer = "We recommend the option that suits the construction and soil at your place; we explain both on site."
++++
+
+# Termite Control in Casuarina – Eco-Friendly & Licensed
+
+We deliver termite control across Casuarina. Our licensed techs use low-tox
+products that keep families, pets and the coast safe. Call 0405 508 035 for fast
+help or a quote today.
+
+**Call 0405 508 035**
+
+## Why choose us
+
+- Local technicians based near the Tweed Coast
+- Low-tox methods safe for kids and pets
+- Clear pricing and written reports
+
+## What’s included / excluded
+
+Includes: onsite assessment, targeted termite control and follow-up advice. Excludes: snakes, mammals, birds or reptiles.
+
+## Pricing & timing
+
+Most termite treatments in Casuarina start from $1,100 and take 1–2 days. Monitoring plans from $30 per station each quarter.
+
+## Our process
+
+1. Call or book online to schedule a visit.
+2. We inspect and identify the pests and entry points.
+3. We treat the problem with low-tox methods suited to your property.
+4. We provide a report and tips to keep pests away.
+
+## Local proof
+
+We’re based in Kingscliff and regularly service Casuarina and nearby spots like Pottsville and Cabarita.
+
+## Reviews
+
+> “Prompt and professional.” – Sarah M
+> “No more pests after one visit.” – Jake R
+
+## More help
+
+Need termite inspections? See our [Termite Inspections in Casuarina](/termite-inspections-casuarina/).
+
+Looking for ant control? Check out [Ant Control in Casuarina](/ant-control-casuarina/).
+
+Ready for termite control? **Call 0405 508 035**.

--- a/content/termite-control-chinderah.md
+++ b/content/termite-control-chinderah.md
@@ -1,0 +1,69 @@
++++
+title = "Termite Control Chinderah | Eco-Friendly & Licensed | Local Pest Co"
+meta_desc = "Local, low-tox termite control in Chinderah. Licensed techs, fast call-outs, clear pricing. Book today: 0405 508 035."
+[service]
+serviceType = "Termite Control"
+areaServed = "Chinderah"
+priceRange = "$1,100"
+[[faq]]
+question = "Do you remove snakes?"
+answer = "We don’t remove snakes. For safety, please contact a licensed snake catcher. If a snake is inside, keep clear and close interior doors until help arrives."
+[[faq]]
+question = "Do you handle mammals like possums, rats, or mice?"
+answer = "We don’t handle mammals. We focus on termites and small insects. Please contact licensed wildlife or rodent specialists for these."
+[[faq]]
+question = "Do you remove birds or bats?"
+answer = "We don’t manage birds or bats. Seek licensed wildlife handlers and follow NSW regulations."
+[[faq]]
+question = "How often should we book termite inspections?"
+answer = "We suggest annual inspections in Chinderah to catch activity early."
+[[faq]]
+question = "Is baiting or a barrier better?"
+answer = "We recommend the option that suits the construction and soil at your place; we explain both on site."
++++
+
+# Termite Control in Chinderah – Eco-Friendly & Licensed
+
+We deliver termite control across Chinderah. Our licensed techs use low-tox
+products that keep families, pets and the coast safe. Call 0405 508 035 for fast
+help or a quote today.
+
+**Call 0405 508 035**
+
+## Why choose us
+
+- Local technicians based near the Tweed Coast
+- Low-tox methods safe for kids and pets
+- Clear pricing and written reports
+
+## What’s included / excluded
+
+Includes: onsite assessment, targeted termite control and follow-up advice. Excludes: snakes, mammals, birds or reptiles.
+
+## Pricing & timing
+
+Most termite treatments in Chinderah start from $1,100 and take 1–2 days. Monitoring plans from $30 per station each quarter.
+
+## Our process
+
+1. Call or book online to schedule a visit.
+2. We inspect and identify the pests and entry points.
+3. We treat the problem with low-tox methods suited to your property.
+4. We provide a report and tips to keep pests away.
+
+## Local proof
+
+We’re based in Kingscliff and regularly service Chinderah and nearby spots like Cudgen and Casuarina.
+
+## Reviews
+
+> “Prompt and professional.” – Sarah M
+> “No more pests after one visit.” – Jake R
+
+## More help
+
+Need termite inspections? See our [Termite Inspections in Chinderah](/termite-inspections-chinderah/).
+
+Looking for ant control? Check out [Ant Control in Chinderah](/ant-control-chinderah/).
+
+Ready for termite control? **Call 0405 508 035**.

--- a/content/termite-control-cudgen.md
+++ b/content/termite-control-cudgen.md
@@ -1,0 +1,69 @@
++++
+title = "Termite Control Cudgen | Eco-Friendly & Licensed | Local Pest Co"
+meta_desc = "Local, low-tox termite control in Cudgen. Licensed techs, fast call-outs, clear pricing. Book today: 0405 508 035."
+[service]
+serviceType = "Termite Control"
+areaServed = "Cudgen"
+priceRange = "$1,100"
+[[faq]]
+question = "Do you remove snakes?"
+answer = "We don’t remove snakes. For safety, please contact a licensed snake catcher. If a snake is inside, keep clear and close interior doors until help arrives."
+[[faq]]
+question = "Do you handle mammals like possums, rats, or mice?"
+answer = "We don’t handle mammals. We focus on termites and small insects. Please contact licensed wildlife or rodent specialists for these."
+[[faq]]
+question = "Do you remove birds or bats?"
+answer = "We don’t manage birds or bats. Seek licensed wildlife handlers and follow NSW regulations."
+[[faq]]
+question = "How often should we book termite inspections?"
+answer = "We suggest annual inspections in Cudgen to catch activity early."
+[[faq]]
+question = "Is baiting or a barrier better?"
+answer = "We recommend the option that suits the construction and soil at your place; we explain both on site."
++++
+
+# Termite Control in Cudgen – Eco-Friendly & Licensed
+
+We deliver termite control across Cudgen. Our licensed techs use low-tox
+products that keep families, pets and the coast safe. Call 0405 508 035 for fast
+help or a quote today.
+
+**Call 0405 508 035**
+
+## Why choose us
+
+- Local technicians based near the Tweed Coast
+- Low-tox methods safe for kids and pets
+- Clear pricing and written reports
+
+## What’s included / excluded
+
+Includes: onsite assessment, targeted termite control and follow-up advice. Excludes: snakes, mammals, birds or reptiles.
+
+## Pricing & timing
+
+Most termite treatments in Cudgen start from $1,100 and take 1–2 days. Monitoring plans from $30 per station each quarter.
+
+## Our process
+
+1. Call or book online to schedule a visit.
+2. We inspect and identify the pests and entry points.
+3. We treat the problem with low-tox methods suited to your property.
+4. We provide a report and tips to keep pests away.
+
+## Local proof
+
+We’re based in Kingscliff and regularly service Cudgen and nearby spots like Casuarina and Pottsville.
+
+## Reviews
+
+> “Prompt and professional.” – Sarah M
+> “No more pests after one visit.” – Jake R
+
+## More help
+
+Need termite inspections? See our [Termite Inspections in Cudgen](/termite-inspections-cudgen/).
+
+Looking for ant control? Check out [Ant Control in Cudgen](/ant-control-cudgen/).
+
+Ready for termite control? **Call 0405 508 035**.

--- a/content/termite-control-guide.md
+++ b/content/termite-control-guide.md
@@ -1,0 +1,40 @@
++++
+title = "Termite Control Guide | Eco-Friendly & Licensed | Local Pest Co"
+meta_desc = "Signs, treatment options and costs for termite control."
+[[faq]]
+question = "How often should we inspect for termites?"
+answer = "We recommend annual inspections, and more often if you have a history of termites."
+[[faq]]
+question = "What’s the difference between baiting and barriers?"
+answer = "Baiting lures termites to feed and share the toxin, while barriers create a treated zone they can’t cross."
+[[faq]]
+question = "Do treatments come with warranties?"
+answer = "Yes, chemical barriers include up to eight years warranty when we inspect annually."
++++
+# Termite Control Guide – Eco-Friendly & Licensed
+
+We share what we’ve learnt keeping homes termite-free on the Tweed Coast. Our team explains the signs, treatment options and costs so you can choose what suits your place.
+
+**Call 0405 508 035**
+
+## Signs of termites
+
+Look for hollow timber, mud tubes and discarded wings around your property.
+
+## Inspection cadence
+
+We suggest yearly checks, and after heavy rain or renovations.
+
+## Baiting vs barriers
+
+Baiting lets us monitor colonies, while chemical barriers block entry. We assess and recommend the best fit.
+
+## Costs and timeframes
+
+Minor baiting jobs start from $1,100. Full perimeter barriers can take two days and start from $2,200.
+
+## Seasonal advice
+
+Termites stay active year-round in our climate. Keep gardens tidy and drainage clear.
+
+Ready for help? **Call 0405 508 035** or [book an inspection](/pre-purchase-termite-inspections-kingscliff/).

--- a/content/termite-control-murwillumbah.md
+++ b/content/termite-control-murwillumbah.md
@@ -1,0 +1,69 @@
++++
+title = "Termite Control Murwillumbah | Eco-Friendly & Licensed | Local Pest Co"
+meta_desc = "Local, low-tox termite control in Murwillumbah. Licensed techs, fast call-outs, clear pricing. Book today: 0405 508 035."
+[service]
+serviceType = "Termite Control"
+areaServed = "Murwillumbah"
+priceRange = "$1,100"
+[[faq]]
+question = "Do you remove snakes?"
+answer = "We don’t remove snakes. For safety, please contact a licensed snake catcher. If a snake is inside, keep clear and close interior doors until help arrives."
+[[faq]]
+question = "Do you handle mammals like possums, rats, or mice?"
+answer = "We don’t handle mammals. We focus on termites and small insects. Please contact licensed wildlife or rodent specialists for these."
+[[faq]]
+question = "Do you remove birds or bats?"
+answer = "We don’t manage birds or bats. Seek licensed wildlife handlers and follow NSW regulations."
+[[faq]]
+question = "How often should we book termite inspections?"
+answer = "We suggest annual inspections in Murwillumbah to catch activity early."
+[[faq]]
+question = "Is baiting or a barrier better?"
+answer = "We recommend the option that suits the construction and soil at your place; we explain both on site."
++++
+
+# Termite Control in Murwillumbah – Eco-Friendly & Licensed
+
+We deliver termite control across Murwillumbah. Our licensed techs use low-tox
+products that keep families, pets and the coast safe. Call 0405 508 035 for fast
+help or a quote today.
+
+**Call 0405 508 035**
+
+## Why choose us
+
+- Local technicians based near the Tweed Coast
+- Low-tox methods safe for kids and pets
+- Clear pricing and written reports
+
+## What’s included / excluded
+
+Includes: onsite assessment, targeted termite control and follow-up advice. Excludes: snakes, mammals, birds or reptiles.
+
+## Pricing & timing
+
+Most termite treatments in Murwillumbah start from $1,100 and take 1–2 days. Monitoring plans from $30 per station each quarter.
+
+## Our process
+
+1. Call or book online to schedule a visit.
+2. We inspect and identify the pests and entry points.
+3. We treat the problem with low-tox methods suited to your property.
+4. We provide a report and tips to keep pests away.
+
+## Local proof
+
+We’re based in Kingscliff and regularly service Murwillumbah and nearby spots like Chinderah and Cudgen.
+
+## Reviews
+
+> “Prompt and professional.” – Sarah M
+> “No more pests after one visit.” – Jake R
+
+## More help
+
+Need termite inspections? See our [Termite Inspections in Murwillumbah](/termite-inspections-murwillumbah/).
+
+Looking for ant control? Check out [Ant Control in Murwillumbah](/ant-control-murwillumbah/).
+
+Ready for termite control? **Call 0405 508 035**.

--- a/content/termite-control-pottsville.md
+++ b/content/termite-control-pottsville.md
@@ -1,0 +1,69 @@
++++
+title = "Termite Control Pottsville | Eco-Friendly & Licensed | Local Pest Co"
+meta_desc = "Local, low-tox termite control in Pottsville. Licensed techs, fast call-outs, clear pricing. Book today: 0405 508 035."
+[service]
+serviceType = "Termite Control"
+areaServed = "Pottsville"
+priceRange = "$1,100"
+[[faq]]
+question = "Do you remove snakes?"
+answer = "We don’t remove snakes. For safety, please contact a licensed snake catcher. If a snake is inside, keep clear and close interior doors until help arrives."
+[[faq]]
+question = "Do you handle mammals like possums, rats, or mice?"
+answer = "We don’t handle mammals. We focus on termites and small insects. Please contact licensed wildlife or rodent specialists for these."
+[[faq]]
+question = "Do you remove birds or bats?"
+answer = "We don’t manage birds or bats. Seek licensed wildlife handlers and follow NSW regulations."
+[[faq]]
+question = "How often should we book termite inspections?"
+answer = "We suggest annual inspections in Pottsville to catch activity early."
+[[faq]]
+question = "Is baiting or a barrier better?"
+answer = "We recommend the option that suits the construction and soil at your place; we explain both on site."
++++
+
+# Termite Control in Pottsville – Eco-Friendly & Licensed
+
+We deliver termite control across Pottsville. Our licensed techs use low-tox
+products that keep families, pets and the coast safe. Call 0405 508 035 for fast
+help or a quote today.
+
+**Call 0405 508 035**
+
+## Why choose us
+
+- Local technicians based near the Tweed Coast
+- Low-tox methods safe for kids and pets
+- Clear pricing and written reports
+
+## What’s included / excluded
+
+Includes: onsite assessment, targeted termite control and follow-up advice. Excludes: snakes, mammals, birds or reptiles.
+
+## Pricing & timing
+
+Most termite treatments in Pottsville start from $1,100 and take 1–2 days. Monitoring plans from $30 per station each quarter.
+
+## Our process
+
+1. Call or book online to schedule a visit.
+2. We inspect and identify the pests and entry points.
+3. We treat the problem with low-tox methods suited to your property.
+4. We provide a report and tips to keep pests away.
+
+## Local proof
+
+We’re based in Kingscliff and regularly service Pottsville and nearby spots like Cabarita and Murwillumbah.
+
+## Reviews
+
+> “Prompt and professional.” – Sarah M
+> “No more pests after one visit.” – Jake R
+
+## More help
+
+Need termite inspections? See our [Termite Inspections in Pottsville](/termite-inspections-pottsville/).
+
+Looking for ant control? Check out [Ant Control in Pottsville](/ant-control-pottsville/).
+
+Ready for termite control? **Call 0405 508 035**.

--- a/content/termite-inspections-cabarita.md
+++ b/content/termite-inspections-cabarita.md
@@ -1,0 +1,69 @@
++++
+title = "Termite Inspections Cabarita | Eco-Friendly & Licensed | Local Pest Co"
+meta_desc = "Local, low-tox termite inspections in Cabarita. Licensed techs, fast call-outs, clear pricing. Book today: 0405 508 035."
+[service]
+serviceType = "Termite Inspections"
+areaServed = "Cabarita"
+priceRange = "$275 for homes"
+[[faq]]
+question = "Do you remove snakes?"
+answer = "We don’t remove snakes. For safety, please contact a licensed snake catcher. If a snake is inside, keep clear and close interior doors until help arrives."
+[[faq]]
+question = "Do you handle mammals like possums, rats, or mice?"
+answer = "We don’t handle mammals. We focus on termites and small insects. Please contact licensed wildlife or rodent specialists for these."
+[[faq]]
+question = "Do you remove birds or bats?"
+answer = "We don’t manage birds or bats. Seek licensed wildlife handlers and follow NSW regulations."
+[[faq]]
+question = "How long does a termite inspection take?"
+answer = "Most inspections in Cabarita take about 90 minutes for an average home."
+[[faq]]
+question = "Do we get a written report?"
+answer = "Yes, we email a detailed digital report with photos within 24 hours."
++++
+
+# Termite Inspections in Cabarita – Eco-Friendly & Licensed
+
+We deliver termite inspections across Cabarita. Our licensed techs use low-tox
+products that keep families, pets and the coast safe. Call 0405 508 035 for fast
+help or a quote today.
+
+**Call 0405 508 035**
+
+## Why choose us
+
+- Local technicians based near the Tweed Coast
+- Low-tox methods safe for kids and pets
+- Clear pricing and written reports
+
+## What’s included / excluded
+
+Includes: onsite assessment, targeted termite inspections and follow-up advice. Excludes: snakes, mammals, birds or reptiles.
+
+## Pricing & timing
+
+Termite inspections in Cabarita start from $275 for homes and take around 90 minutes.
+
+## Our process
+
+1. Call or book online to schedule a visit.
+2. We inspect and identify the pests and entry points.
+3. We treat the problem with low-tox methods suited to your property.
+4. We provide a report and tips to keep pests away.
+
+## Local proof
+
+We’re based in Kingscliff and regularly service Cabarita and nearby spots like Murwillumbah and Chinderah.
+
+## Reviews
+
+> “Prompt and professional.” – Sarah M
+> “No more pests after one visit.” – Jake R
+
+## More help
+
+Need termite control? See our [Termite Control in Cabarita](/termite-control-cabarita/).
+
+Looking for ant control? Check out [Ant Control in Cabarita](/ant-control-cabarita/).
+
+Ready for termite inspections? **Call 0405 508 035**.

--- a/content/termite-inspections-casuarina.md
+++ b/content/termite-inspections-casuarina.md
@@ -1,0 +1,69 @@
++++
+title = "Termite Inspections Casuarina | Eco-Friendly & Licensed | Local Pest Co"
+meta_desc = "Local, low-tox termite inspections in Casuarina. Licensed techs, fast call-outs, clear pricing. Book today: 0405 508 035."
+[service]
+serviceType = "Termite Inspections"
+areaServed = "Casuarina"
+priceRange = "$275 for homes"
+[[faq]]
+question = "Do you remove snakes?"
+answer = "We don’t remove snakes. For safety, please contact a licensed snake catcher. If a snake is inside, keep clear and close interior doors until help arrives."
+[[faq]]
+question = "Do you handle mammals like possums, rats, or mice?"
+answer = "We don’t handle mammals. We focus on termites and small insects. Please contact licensed wildlife or rodent specialists for these."
+[[faq]]
+question = "Do you remove birds or bats?"
+answer = "We don’t manage birds or bats. Seek licensed wildlife handlers and follow NSW regulations."
+[[faq]]
+question = "How long does a termite inspection take?"
+answer = "Most inspections in Casuarina take about 90 minutes for an average home."
+[[faq]]
+question = "Do we get a written report?"
+answer = "Yes, we email a detailed digital report with photos within 24 hours."
++++
+
+# Termite Inspections in Casuarina – Eco-Friendly & Licensed
+
+We deliver termite inspections across Casuarina. Our licensed techs use low-tox
+products that keep families, pets and the coast safe. Call 0405 508 035 for fast
+help or a quote today.
+
+**Call 0405 508 035**
+
+## Why choose us
+
+- Local technicians based near the Tweed Coast
+- Low-tox methods safe for kids and pets
+- Clear pricing and written reports
+
+## What’s included / excluded
+
+Includes: onsite assessment, targeted termite inspections and follow-up advice. Excludes: snakes, mammals, birds or reptiles.
+
+## Pricing & timing
+
+Termite inspections in Casuarina start from $275 for homes and take around 90 minutes.
+
+## Our process
+
+1. Call or book online to schedule a visit.
+2. We inspect and identify the pests and entry points.
+3. We treat the problem with low-tox methods suited to your property.
+4. We provide a report and tips to keep pests away.
+
+## Local proof
+
+We’re based in Kingscliff and regularly service Casuarina and nearby spots like Pottsville and Cabarita.
+
+## Reviews
+
+> “Prompt and professional.” – Sarah M
+> “No more pests after one visit.” – Jake R
+
+## More help
+
+Need termite control? See our [Termite Control in Casuarina](/termite-control-casuarina/).
+
+Looking for ant control? Check out [Ant Control in Casuarina](/ant-control-casuarina/).
+
+Ready for termite inspections? **Call 0405 508 035**.

--- a/content/termite-inspections-chinderah.md
+++ b/content/termite-inspections-chinderah.md
@@ -1,0 +1,69 @@
++++
+title = "Termite Inspections Chinderah | Eco-Friendly & Licensed | Local Pest Co"
+meta_desc = "Local, low-tox termite inspections in Chinderah. Licensed techs, fast call-outs, clear pricing. Book today: 0405 508 035."
+[service]
+serviceType = "Termite Inspections"
+areaServed = "Chinderah"
+priceRange = "$275 for homes"
+[[faq]]
+question = "Do you remove snakes?"
+answer = "We don’t remove snakes. For safety, please contact a licensed snake catcher. If a snake is inside, keep clear and close interior doors until help arrives."
+[[faq]]
+question = "Do you handle mammals like possums, rats, or mice?"
+answer = "We don’t handle mammals. We focus on termites and small insects. Please contact licensed wildlife or rodent specialists for these."
+[[faq]]
+question = "Do you remove birds or bats?"
+answer = "We don’t manage birds or bats. Seek licensed wildlife handlers and follow NSW regulations."
+[[faq]]
+question = "How long does a termite inspection take?"
+answer = "Most inspections in Chinderah take about 90 minutes for an average home."
+[[faq]]
+question = "Do we get a written report?"
+answer = "Yes, we email a detailed digital report with photos within 24 hours."
++++
+
+# Termite Inspections in Chinderah – Eco-Friendly & Licensed
+
+We deliver termite inspections across Chinderah. Our licensed techs use low-tox
+products that keep families, pets and the coast safe. Call 0405 508 035 for fast
+help or a quote today.
+
+**Call 0405 508 035**
+
+## Why choose us
+
+- Local technicians based near the Tweed Coast
+- Low-tox methods safe for kids and pets
+- Clear pricing and written reports
+
+## What’s included / excluded
+
+Includes: onsite assessment, targeted termite inspections and follow-up advice. Excludes: snakes, mammals, birds or reptiles.
+
+## Pricing & timing
+
+Termite inspections in Chinderah start from $275 for homes and take around 90 minutes.
+
+## Our process
+
+1. Call or book online to schedule a visit.
+2. We inspect and identify the pests and entry points.
+3. We treat the problem with low-tox methods suited to your property.
+4. We provide a report and tips to keep pests away.
+
+## Local proof
+
+We’re based in Kingscliff and regularly service Chinderah and nearby spots like Cudgen and Casuarina.
+
+## Reviews
+
+> “Prompt and professional.” – Sarah M
+> “No more pests after one visit.” – Jake R
+
+## More help
+
+Need termite control? See our [Termite Control in Chinderah](/termite-control-chinderah/).
+
+Looking for ant control? Check out [Ant Control in Chinderah](/ant-control-chinderah/).
+
+Ready for termite inspections? **Call 0405 508 035**.

--- a/content/termite-inspections-cudgen.md
+++ b/content/termite-inspections-cudgen.md
@@ -1,0 +1,69 @@
++++
+title = "Termite Inspections Cudgen | Eco-Friendly & Licensed | Local Pest Co"
+meta_desc = "Local, low-tox termite inspections in Cudgen. Licensed techs, fast call-outs, clear pricing. Book today: 0405 508 035."
+[service]
+serviceType = "Termite Inspections"
+areaServed = "Cudgen"
+priceRange = "$275 for homes"
+[[faq]]
+question = "Do you remove snakes?"
+answer = "We don’t remove snakes. For safety, please contact a licensed snake catcher. If a snake is inside, keep clear and close interior doors until help arrives."
+[[faq]]
+question = "Do you handle mammals like possums, rats, or mice?"
+answer = "We don’t handle mammals. We focus on termites and small insects. Please contact licensed wildlife or rodent specialists for these."
+[[faq]]
+question = "Do you remove birds or bats?"
+answer = "We don’t manage birds or bats. Seek licensed wildlife handlers and follow NSW regulations."
+[[faq]]
+question = "How long does a termite inspection take?"
+answer = "Most inspections in Cudgen take about 90 minutes for an average home."
+[[faq]]
+question = "Do we get a written report?"
+answer = "Yes, we email a detailed digital report with photos within 24 hours."
++++
+
+# Termite Inspections in Cudgen – Eco-Friendly & Licensed
+
+We deliver termite inspections across Cudgen. Our licensed techs use low-tox
+products that keep families, pets and the coast safe. Call 0405 508 035 for fast
+help or a quote today.
+
+**Call 0405 508 035**
+
+## Why choose us
+
+- Local technicians based near the Tweed Coast
+- Low-tox methods safe for kids and pets
+- Clear pricing and written reports
+
+## What’s included / excluded
+
+Includes: onsite assessment, targeted termite inspections and follow-up advice. Excludes: snakes, mammals, birds or reptiles.
+
+## Pricing & timing
+
+Termite inspections in Cudgen start from $275 for homes and take around 90 minutes.
+
+## Our process
+
+1. Call or book online to schedule a visit.
+2. We inspect and identify the pests and entry points.
+3. We treat the problem with low-tox methods suited to your property.
+4. We provide a report and tips to keep pests away.
+
+## Local proof
+
+We’re based in Kingscliff and regularly service Cudgen and nearby spots like Casuarina and Pottsville.
+
+## Reviews
+
+> “Prompt and professional.” – Sarah M
+> “No more pests after one visit.” – Jake R
+
+## More help
+
+Need termite control? See our [Termite Control in Cudgen](/termite-control-cudgen/).
+
+Looking for ant control? Check out [Ant Control in Cudgen](/ant-control-cudgen/).
+
+Ready for termite inspections? **Call 0405 508 035**.

--- a/content/termite-inspections-murwillumbah.md
+++ b/content/termite-inspections-murwillumbah.md
@@ -1,0 +1,69 @@
++++
+title = "Termite Inspections Murwillumbah | Eco-Friendly & Licensed | Local Pest Co"
+meta_desc = "Local, low-tox termite inspections in Murwillumbah. Licensed techs, fast call-outs, clear pricing. Book today: 0405 508 035."
+[service]
+serviceType = "Termite Inspections"
+areaServed = "Murwillumbah"
+priceRange = "$275 for homes"
+[[faq]]
+question = "Do you remove snakes?"
+answer = "We don’t remove snakes. For safety, please contact a licensed snake catcher. If a snake is inside, keep clear and close interior doors until help arrives."
+[[faq]]
+question = "Do you handle mammals like possums, rats, or mice?"
+answer = "We don’t handle mammals. We focus on termites and small insects. Please contact licensed wildlife or rodent specialists for these."
+[[faq]]
+question = "Do you remove birds or bats?"
+answer = "We don’t manage birds or bats. Seek licensed wildlife handlers and follow NSW regulations."
+[[faq]]
+question = "How long does a termite inspection take?"
+answer = "Most inspections in Murwillumbah take about 90 minutes for an average home."
+[[faq]]
+question = "Do we get a written report?"
+answer = "Yes, we email a detailed digital report with photos within 24 hours."
++++
+
+# Termite Inspections in Murwillumbah – Eco-Friendly & Licensed
+
+We deliver termite inspections across Murwillumbah. Our licensed techs use low-
+tox products that keep families, pets and the coast safe. Call 0405 508 035 for
+fast help or a quote today.
+
+**Call 0405 508 035**
+
+## Why choose us
+
+- Local technicians based near the Tweed Coast
+- Low-tox methods safe for kids and pets
+- Clear pricing and written reports
+
+## What’s included / excluded
+
+Includes: onsite assessment, targeted termite inspections and follow-up advice. Excludes: snakes, mammals, birds or reptiles.
+
+## Pricing & timing
+
+Termite inspections in Murwillumbah start from $275 for homes and take around 90 minutes.
+
+## Our process
+
+1. Call or book online to schedule a visit.
+2. We inspect and identify the pests and entry points.
+3. We treat the problem with low-tox methods suited to your property.
+4. We provide a report and tips to keep pests away.
+
+## Local proof
+
+We’re based in Kingscliff and regularly service Murwillumbah and nearby spots like Chinderah and Cudgen.
+
+## Reviews
+
+> “Prompt and professional.” – Sarah M
+> “No more pests after one visit.” – Jake R
+
+## More help
+
+Need termite control? See our [Termite Control in Murwillumbah](/termite-control-murwillumbah/).
+
+Looking for ant control? Check out [Ant Control in Murwillumbah](/ant-control-murwillumbah/).
+
+Ready for termite inspections? **Call 0405 508 035**.

--- a/content/termite-inspections-pottsville.md
+++ b/content/termite-inspections-pottsville.md
@@ -1,0 +1,69 @@
++++
+title = "Termite Inspections Pottsville | Eco-Friendly & Licensed | Local Pest Co"
+meta_desc = "Local, low-tox termite inspections in Pottsville. Licensed techs, fast call-outs, clear pricing. Book today: 0405 508 035."
+[service]
+serviceType = "Termite Inspections"
+areaServed = "Pottsville"
+priceRange = "$275 for homes"
+[[faq]]
+question = "Do you remove snakes?"
+answer = "We don’t remove snakes. For safety, please contact a licensed snake catcher. If a snake is inside, keep clear and close interior doors until help arrives."
+[[faq]]
+question = "Do you handle mammals like possums, rats, or mice?"
+answer = "We don’t handle mammals. We focus on termites and small insects. Please contact licensed wildlife or rodent specialists for these."
+[[faq]]
+question = "Do you remove birds or bats?"
+answer = "We don’t manage birds or bats. Seek licensed wildlife handlers and follow NSW regulations."
+[[faq]]
+question = "How long does a termite inspection take?"
+answer = "Most inspections in Pottsville take about 90 minutes for an average home."
+[[faq]]
+question = "Do we get a written report?"
+answer = "Yes, we email a detailed digital report with photos within 24 hours."
++++
+
+# Termite Inspections in Pottsville – Eco-Friendly & Licensed
+
+We deliver termite inspections across Pottsville. Our licensed techs use low-tox
+products that keep families, pets and the coast safe. Call 0405 508 035 for fast
+help or a quote today.
+
+**Call 0405 508 035**
+
+## Why choose us
+
+- Local technicians based near the Tweed Coast
+- Low-tox methods safe for kids and pets
+- Clear pricing and written reports
+
+## What’s included / excluded
+
+Includes: onsite assessment, targeted termite inspections and follow-up advice. Excludes: snakes, mammals, birds or reptiles.
+
+## Pricing & timing
+
+Termite inspections in Pottsville start from $275 for homes and take around 90 minutes.
+
+## Our process
+
+1. Call or book online to schedule a visit.
+2. We inspect and identify the pests and entry points.
+3. We treat the problem with low-tox methods suited to your property.
+4. We provide a report and tips to keep pests away.
+
+## Local proof
+
+We’re based in Kingscliff and regularly service Pottsville and nearby spots like Cabarita and Murwillumbah.
+
+## Reviews
+
+> “Prompt and professional.” – Sarah M
+> “No more pests after one visit.” – Jake R
+
+## More help
+
+Need termite control? See our [Termite Control in Pottsville](/termite-control-pottsville/).
+
+Looking for ant control? Check out [Ant Control in Pottsville](/ant-control-pottsville/).
+
+Ready for termite inspections? **Call 0405 508 035**.

--- a/docs/seo-changelog.md
+++ b/docs/seo-changelog.md
@@ -1,0 +1,46 @@
+# SEO Changelog
+
+| URL | type | date | target queries | inbound links | schema added |
+| --- | --- | --- | --- | --- | --- |
+| /pest-control-kingscliff/ | new | 2025-09-09 | pest control kingscliff | site nav, suburb pages | LocalBusiness, Service, FAQPage |
+| /termite-control-guide/ | new | 2025-09-09 | termite treatment guide | kingscliff page, termite services | FAQPage |
+| /pre-purchase-termite-inspections-kingscliff/ | new | 2025-09-09 | pre purchase termite inspection kingscliff | kingscliff page, termite guide | Service, FAQPage |
+| /termite-baiting-systems-kingscliff/ | new | 2025-09-09 | termite baiting kingscliff | kingscliff page, termite guide | Service, FAQPage |
+| /termite-barriers-kingscliff/ | new | 2025-09-09 | termite barriers kingscliff | kingscliff page, termite guide | Service, FAQPage |
+| /termite-control-casuarina/ | new | 2025-09-09 | termite control casuarina | kingscliff page, sibling services | Service, FAQPage |
+| /termite-inspections-casuarina/ | new | 2025-09-09 | termite inspections casuarina | kingscliff page, sibling services | Service, FAQPage |
+| /ant-control-casuarina/ | new | 2025-09-09 | ant control casuarina | kingscliff page, sibling services | Service, FAQPage |
+| /cockroach-control-casuarina/ | new | 2025-09-09 | cockroach control casuarina | kingscliff page, sibling services | Service, FAQPage |
+| /spider-control-casuarina/ | new | 2025-09-09 | spider control casuarina | kingscliff page, sibling services | Service, FAQPage |
+| /termite-control-pottsville/ | new | 2025-09-09 | termite control pottsville | kingscliff page, sibling services | Service, FAQPage |
+| /termite-inspections-pottsville/ | new | 2025-09-09 | termite inspections pottsville | kingscliff page, sibling services | Service, FAQPage |
+| /ant-control-pottsville/ | new | 2025-09-09 | ant control pottsville | kingscliff page, sibling services | Service, FAQPage |
+| /cockroach-control-pottsville/ | new | 2025-09-09 | cockroach control pottsville | kingscliff page, sibling services | Service, FAQPage |
+| /spider-control-pottsville/ | new | 2025-09-09 | spider control pottsville | kingscliff page, sibling services | Service, FAQPage |
+| /termite-control-cabarita/ | new | 2025-09-09 | termite control cabarita | kingscliff page, sibling services | Service, FAQPage |
+| /termite-inspections-cabarita/ | new | 2025-09-09 | termite inspections cabarita | kingscliff page, sibling services | Service, FAQPage |
+| /ant-control-cabarita/ | new | 2025-09-09 | ant control cabarita | kingscliff page, sibling services | Service, FAQPage |
+| /cockroach-control-cabarita/ | new | 2025-09-09 | cockroach control cabarita | kingscliff page, sibling services | Service, FAQPage |
+| /spider-control-cabarita/ | new | 2025-09-09 | spider control cabarita | kingscliff page, sibling services | Service, FAQPage |
+| /termite-control-murwillumbah/ | new | 2025-09-09 | termite control murwillumbah | kingscliff page, sibling services | Service, FAQPage |
+| /termite-inspections-murwillumbah/ | new | 2025-09-09 | termite inspections murwillumbah | kingscliff page, sibling services | Service, FAQPage |
+| /ant-control-murwillumbah/ | new | 2025-09-09 | ant control murwillumbah | kingscliff page, sibling services | Service, FAQPage |
+| /cockroach-control-murwillumbah/ | new | 2025-09-09 | cockroach control murwillumbah | kingscliff page, sibling services | Service, FAQPage |
+| /spider-control-murwillumbah/ | new | 2025-09-09 | spider control murwillumbah | kingscliff page, sibling services | Service, FAQPage |
+| /termite-control-chinderah/ | new | 2025-09-09 | termite control chinderah | kingscliff page, sibling services | Service, FAQPage |
+| /termite-inspections-chinderah/ | new | 2025-09-09 | termite inspections chinderah | kingscliff page, sibling services | Service, FAQPage |
+| /ant-control-chinderah/ | new | 2025-09-09 | ant control chinderah | kingscliff page, sibling services | Service, FAQPage |
+| /cockroach-control-chinderah/ | new | 2025-09-09 | cockroach control chinderah | kingscliff page, sibling services | Service, FAQPage |
+| /spider-control-chinderah/ | new | 2025-09-09 | spider control chinderah | kingscliff page, sibling services | Service, FAQPage |
+| /termite-control-cudgen/ | new | 2025-09-09 | termite control cudgen | kingscliff page, sibling services | Service, FAQPage |
+| /termite-inspections-cudgen/ | new | 2025-09-09 | termite inspections cudgen | kingscliff page, sibling services | Service, FAQPage |
+| /ant-control-cudgen/ | new | 2025-09-09 | ant control cudgen | kingscliff page, sibling services | Service, FAQPage |
+| /cockroach-control-cudgen/ | new | 2025-09-09 | cockroach control cudgen | kingscliff page, sibling services | Service, FAQPage |
+| /spider-control-cudgen/ | new | 2025-09-09 | spider control cudgen | kingscliff page, sibling services | Service, FAQPage |
+| /snake-control-kingscliff/ → /pest-control-kingscliff/#we-dont-do | redirect | 2025-09-09 | n/a | n/a | n/a |
+| /possum-removal-kingscliff/ → /pest-control-kingscliff/#we-dont-do | redirect | 2025-09-09 | n/a | n/a | n/a |
+| /rodent-control-kingscliff/ → /pest-control-kingscliff/#we-dont-do | redirect | 2025-09-09 | n/a | n/a | n/a |
+| /rodent-pest-control → /pest-control-kingscliff/#we-dont-do | redirect | 2025-09-09 | n/a | n/a | n/a |
+| /rodent-pest-control/ → /pest-control-kingscliff/#we-dont-do | redirect | 2025-09-09 | n/a | n/a | n/a |
+| /bird-control-kingscliff/ → /pest-control-kingscliff/#we-dont-do | redirect | 2025-09-09 | n/a | n/a | n/a |
+| /rodent-control-services-what-works-best-find-out-for-2025/ → /pest-control-kingscliff/#we-dont-do | redirect | 2025-09-09 | n/a | n/a | n/a |

--- a/layouts/partials/faq.html
+++ b/layouts/partials/faq.html
@@ -1,5 +1,5 @@
 {{- if .Params.faq }}
-<section class="faq">
+<section class="faq"{{ with .Params.faq_id }} id="{{ . }}"{{ end }}>
   <h2>FAQs</h2>
   {{ range .Params.faq }}
   <details>

--- a/layouts/partials/seo/schema.html
+++ b/layouts/partials/seo/schema.html
@@ -6,6 +6,17 @@
 {{- with .Site.Params.logo }}{{ $org = merge $org (dict "logo" (absURL .)) }}{{ end -}}
 {{- $schemas = $schemas | append $org -}}
 
+{{- /* LocalBusiness schema */ -}}
+{{- $areas := slice "Kingscliff" "Casuarina" "Cabarita" "Pottsville" "Murwillumbah" "Chinderah" "Cudgen" "Fingal Head" "Banora Point" "Terranora" "Tweed Heads" -}}
+{{- $sameAs := slice -}}
+{{- with .Site.Params.social.facebook }}{{ $sameAs = $sameAs | append . }}{{ end -}}
+{{- with .Site.Params.social.twitter }}{{ $sameAs = $sameAs | append . }}{{ end -}}
+{{- $lb := dict "@type" "LocalBusiness" "@id" (printf "%s#localbusiness" $base) "name" .Site.Title "url" $base "telephone" "0405 508 035" "areaServed" $areas "sameAs" $sameAs "address" (dict "@type" "PostalAddress" "addressLocality" "Kingscliff" "addressRegion" "NSW" "addressCountry" "AU") -}}
+{{- $hours := slice (dict "@type" "OpeningHoursSpecification" "dayOfWeek" "Monday" "opens" "08:00" "closes" "17:00") (dict "@type" "OpeningHoursSpecification" "dayOfWeek" "Tuesday" "opens" "08:00" "closes" "17:00") (dict "@type" "OpeningHoursSpecification" "dayOfWeek" "Wednesday" "opens" "08:00" "closes" "17:00") (dict "@type" "OpeningHoursSpecification" "dayOfWeek" "Thursday" "opens" "08:00" "closes" "17:00") (dict "@type" "OpeningHoursSpecification" "dayOfWeek" "Friday" "opens" "08:00" "closes" "17:00") -}}
+{{- $lb = merge $lb (dict "openingHoursSpecification" $hours) -}}
+{{- with .Site.Params.logo }}{{ $lb = merge $lb (dict "image" (absURL .)) }}{{ end -}}
+{{- $schemas = $schemas | append $lb -}}
+
 {{- $website := dict "@type" "WebSite" "name" .Site.Title "url" $base -}}
 {{- with .Site.Params.search.url -}}
   {{- $website = merge $website (dict "potentialAction" (dict "@type" "SearchAction" "target" (printf "%s?q={search_term_string}" .) "query-input" "required name=search_term_string")) -}}
@@ -27,6 +38,19 @@
 {{- end -}}
 {{- if gt (len $crumbs) 0 -}}
   {{- $schemas = $schemas | append (dict "@type" "BreadcrumbList" "itemListElement" $crumbs) -}}
+{{- end -}}
+
+{{- if .Params.faq -}}
+  {{- $faqitems := slice -}}
+  {{- range .Params.faq -}}
+    {{- $faqitems = $faqitems | append (dict "@type" "Question" "name" .question "acceptedAnswer" (dict "@type" "Answer" "text" .answer)) -}}
+  {{- end -}}
+  {{- $schemas = $schemas | append (dict "@type" "FAQPage" "mainEntity" $faqitems) -}}
+{{- end -}}
+
+{{- with .Params.service -}}
+  {{- $svc := merge (dict "@type" "Service") . -}}
+  {{- $schemas = $schemas | append $svc -}}
 {{- end -}}
 
 {{- if .IsPage -}}

--- a/static/_redirects
+++ b/static/_redirects
@@ -1,6 +1,6 @@
 # Redirect old service pages to service landing page
 /ant-control-kingscliff/ /services 301
-/snake-control-kingscliff/ /services 301
+/snake-control-kingscliff/ /pest-control-kingscliff/#we-dont-do 301
 /eco-friendly-pest-control-kingscliff/ /services 301
 /termite-inspection-kingscliff/ /services 301
 /termite-control-kingscliff/ /services 301
@@ -9,19 +9,21 @@
 /emergency-pest-control-kingscliff/ /services 301
 /german-cockroach-control-kingscliff/ /services 301
 /spider-identification-kingscliff/ /services 301
-/possum-removal-kingscliff/ /services 301
-/bird-control-kingscliff/ /services 301
+/possum-removal-kingscliff/ /pest-control-kingscliff/#we-dont-do 301
+/bird-control-kingscliff/ /pest-control-kingscliff/#we-dont-do 301
 /moth-control-kingscliff/ /services 301
 /tick-control-kingscliff/ /services 301
 /mosquito-control-kingscliff/ /services 301
 /residential-pest-control-in-kingscliff/ /services 301
-/rodent-control-kingscliff/ /services 301
+/rodent-control-kingscliff/ /pest-control-kingscliff/#we-dont-do 301
 /silverfish-control-kingscliff/ /services 301
 /spider-control-kingscliff/ /services 301
 /wasp-and-bee-removal-kingscliff/ /services 301
 /flea-control-kingscliff/ /services 301
 /bed-bug-treatment-kingscliff/ /services 301
 /bed-bug-inspection-kingscliff/ /services 301
+/rodent-pest-control /pest-control-kingscliff/#we-dont-do 301
+/rodent-pest-control/ /pest-control-kingscliff/#we-dont-do 301
 
 # Redirect location pages to locations landing page
 /cabarita-beach/ /locations 301
@@ -36,7 +38,7 @@
 /commercial-pest-control-solutions-for-businesses-7-shocking-benefits/ / 301
 /pest-control-for-cafes-offices-and-shops-2025-secrets-revealed/ / 301
 /how-local-pest-companies-support-community-health-5-powerful-ways/ / 301
-/rodent-control-services-what-works-best-find-out-for-2025/ / 301
+/rodent-control-services-what-works-best-find-out-for-2025/ /pest-control-kingscliff/#we-dont-do 301
 /top-termite-treatment-options-in-australia-2025-kingscliff-guide/ / 301
 /choosing-a-safe-and-eco-friendly-pest-control-option-2025-guide/ / 301
 /number-of-nsw-smokers-drops-to-lowest-levels-on-record-see-how/ / 301


### PR DESCRIPTION
## Summary
- add Kingscliff pest control cornerstone with FAQ anchor
- implement LocalBusiness/Service/FAQ schema and update redirects for non-offered services
- generate termite hub and suburb service pages with first-person eco-friendly copy

## Testing
- `hugo --gc --minify`
- `html-validate public/**/*.html` *(fails: attr-quotes, tel-non-breaking, etc.)*
- `htmltest` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bf7d0babd48325854ef94b468aef99