### PR TITLE
Add Kingscliff possum removal info page and remove redirect

### DIFF
--- a/content/possum-removal-kingscliff.md
+++ b/content/possum-removal-kingscliff.md
@@ -1,0 +1,42 @@
++++
+title = "Possum Removal in Kingscliff"
+description = "We don't remove possums but can connect you with licensed catchers and explain NSW laws."
+keywords = ["possum removal kingscliff", "kingscliff possum catcher", "nsw possum laws"]
+
+[[faq]]
+question = "Do you remove possums?"
+answer = "No. Possums are protected in NSW and must be handled by a licensed wildlife controller."
+
+[[faq]]
+question = "Who can remove a possum from my home?"
+answer = "Only licensed removalists may trap and relocate possums, and they must release them within 50 metres of capture."
+
+[[faq]]
+question = "What are the NSW laws about possum removal?"
+answer = "It's illegal to harm or relocate possums without a licence. Licensed catchers must release them nearby after dark."
++++
+
+## Possums in Kingscliff
+
+Brushtail and ringtail possums are common around Kingscliff. While they can be noisy in roofs, they're native wildlife and protected under NSW law.
+
+## Need a Possum Removed?
+
+I don't offer possum trapping or relocation, but these licensed removalists can help:
+
+- [Frontline Pest Control](https://frontlinepestcontrol.com.au/possum-catcher-kingscliff/)
+- [Gold Coast Pest Services](https://www.goldcoastpestservices.com.au/possum-removal)
+
+## NSW Possum Laws
+
+In New South Wales, possums are protected. The National Parks and Wildlife Act requires that:
+
+- Only licensed wildlife handlers may capture possums.
+- Trapped possums must be released on the same property within 50 metres of where they were caught.
+- Relocation or harm without a permit is illegal.
+
+For more detail, see the [NSW Department of Planning and Environment](https://www.environment.nsw.gov.au/topics/animals-and-plants/native-animals/native-animal-facts/possum) guidelines.
+
+## Need General Pest Control?
+
+For other pest issues, call me on 0405 508 035 or send a message through the contact page.

--- a/static/_redirects
+++ b/static/_redirects
@@ -9,7 +9,6 @@
 /emergency-pest-control-kingscliff/ /services 301
 /german-cockroach-control-kingscliff/ /services 301
 /spider-identification-kingscliff/ /services 301
-/possum-removal-kingscliff/ /services 301
 /bird-control-kingscliff/ /services 301
 /moth-control-kingscliff/ /services 301
 /tick-control-kingscliff/ /services 301


### PR DESCRIPTION
## Summary
- add possum removal page that explains NSW laws and links to licensed removalists
- drop redirect so the new page resolves directly

## Testing
- `hugo`


------
https://chatgpt.com/codex/tasks/task_e_68c1f641b54083259c7c874bf182084d