### PR TITLE
Add blog post on koala chlamydia vaccine

### DIFF
--- a/content/blog/koala-chlamydia-vaccine.md
+++ b/content/blog/koala-chlamydia-vaccine.md
@@ -1,0 +1,23 @@
++++
+title = "Nationwide chlamydia vaccine offers new hope for koalas"
+date = 2025-09-10T00:00:00+10:00
+meta_desc = "Australia approves a single-dose koala chlamydia vaccine, promising relief for endangered populations amid steep declines."
+author = "Local Pest Co"
+tags = ["koalas", "conservation", "vaccines", "wildlife"]
++++
+
+Australia has approved the first nationwide rollout of a koala chlamydia vaccine, a breakthrough that could help reverse the species' decline. Developed by the University of the Sunshine Coast (UniSC), the single-dose vaccine reduces chlamydia-related mortality in wild populations by at least 65% while preventing debilitating symptoms during breeding age [^abc].
+
+## Why koalas need urgent protection
+
+Koalas across Queensland, New South Wales and the Australian Capital Territory were listed as endangered in 2022. South-east Queensland's wild population has dropped below 16,000 due to habitat loss, vehicle strikes, dog attacks and widespread chlamydia infections [^abc]. Recent research underscores how disease and environmental pressures together are pushing the species toward extinction [^nature].
+
+## What the vaccine means for conservation
+
+The UniSC vaccine's single-dose design makes it practical for use in the wild, unlike two-dose alternatives. Researchers and conservation groups are urging government support to deliver the vaccine to at-risk koala populations in Queensland and New South Wales by the end of 2026 [^abc]. A successful rollout could turn the tide for struggling colonies and keep this iconic marsupial on the landscape for generations.
+
+## References
+
+[^abc]: Shorthouse, J., & Ross, J. (2025, September 10). *First koala chlamydia vaccine approved for rollout across Australia*. ABC News. https://www.abc.net.au/news/2025-09-10/koala-chlamydia-vaccine-approved-for-australia-wide-rollout/105747236
+[^nature]: Phillips, S., Hanger, J., Grosmaire, J., Mehdi, A., Jelocnik, M., Wong, J., & Timms, P. (2024). *Immunisation of koalas against Chlamydia pecorum results in significant protection against chlamydial disease and mortality*. NPJ Vaccines. https://www.nature.com/articles/s41541-024-00938-5
+


### PR DESCRIPTION
## Summary
- add SEO-focused blog post covering nationwide approval of single-dose koala chlamydia vaccine and its conservation impact

## Testing
- `hugo --gc --minify`
- `htmltest` *(fails: command not found)*
- `html-validate public/**/*.html` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1fca5b6988325bd852e15f0a60b7f