### PR TITLE
Add Tweed.Cloud footer credit

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -103,6 +103,7 @@
       </a>
     </div>
     <p>Licence No. 5073077 | Licence holder: Mr SHANNON KITCHENER | Status: Issued | Licence type: PMT-TP – Pest Management Technician (Timber Pest Control) | Date issued: 20/02/2025 | Expiry date: 14/01/2030</p>
+    <p class="developer-credit"><a class="tweed-credit" href="https://tweed.cloud/" target="_blank" rel="noopener">Website developed by Tweed.Cloud<span class="cursor">_</span></a></p>
   </footer>
   <script src="{{ "/js/main.js" | relURL }}" defer></script>
 </body>

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -411,3 +411,37 @@ main {
   opacity: 0;
   visibility: hidden;
 }
+
+.developer-credit {
+  margin-top: 0.5rem;
+  margin-bottom: 0;
+}
+
+.tweed-credit {
+  background-color: #000;
+  color: #00ff00;
+  font-family: monospace;
+  display: inline-block;
+  padding: 0.2rem 0.4rem;
+  font-size: 0.75rem;
+  text-decoration: none;
+}
+
+.tweed-credit:hover,
+.tweed-credit:focus {
+  color: #00ff00;
+  text-decoration: none;
+}
+
+.tweed-credit .cursor {
+  animation: blink 1s steps(1, end) infinite;
+}
+
+@keyframes blink {
+  from, to {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0;
+  }
+}


### PR DESCRIPTION
## Summary
- Add developer credit in the footer linking to Tweed.Cloud with a blinking terminal cursor
- Style credit with small black box and green monospace text

## Testing
- `hugo`

------
https://chatgpt.com/codex/tasks/task_e_68c22a8b67108325864670948b26a895