### PR TITLE
Add seo h1 shortcode and update location headings

### DIFF
--- a/content/locations/alstonvale.md
+++ b/content/locations/alstonvale.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Alstonvale"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Ballina Shire."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Alstonvale. Same or next-day support across Ballina Shire.
 

--- a/content/locations/alstonville.md
+++ b/content/locations/alstonville.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Alstonville"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Ballina Shire."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Alstonville. Same or next-day support across Ballina Shire.
 

--- a/content/locations/back-creek.md
+++ b/content/locations/back-creek.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Back Creek"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Tweed Valley."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Back Creek. Same or next-day support across Tweed Valley.
 

--- a/content/locations/ballina.md
+++ b/content/locations/ballina.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Ballina"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Ballina Shire."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Ballina. Same or next-day support across Ballina Shire.
 

--- a/content/locations/bangalow.md
+++ b/content/locations/bangalow.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Bangalow"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Byron Shire."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Bangalow. Same or next-day support across Byron Shire.
 

--- a/content/locations/banora-point.md
+++ b/content/locations/banora-point.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Banora Point"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Tweed Coast."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Banora Point. Same or next-day support across Tweed Coast.
 

--- a/content/locations/bexhill.md
+++ b/content/locations/bexhill.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Bexhill"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Lismore Region."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Bexhill. Same or next-day support across Lismore Region.
 

--- a/content/locations/bilambil-heights.md
+++ b/content/locations/bilambil-heights.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Bilambil Heights"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Tweed Coast."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Bilambil Heights. Same or next-day support across Tweed Coast.
 

--- a/content/locations/bilambil.md
+++ b/content/locations/bilambil.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Bilambil"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Tweed Coast."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Bilambil. Same or next-day support across Tweed Coast.
 

--- a/content/locations/billinudgel.md
+++ b/content/locations/billinudgel.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Billinudgel"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Byron Shire."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Billinudgel. Same or next-day support across Byron Shire.
 

--- a/content/locations/binna-burra.md
+++ b/content/locations/binna-burra.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Binna Burra"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Byron Shire."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Binna Burra. Same or next-day support across Byron Shire.
 

--- a/content/locations/bogangar.md
+++ b/content/locations/bogangar.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Bogangar"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Tweed Coast."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Bogangar. Same or next-day support across Tweed Coast.
 

--- a/content/locations/bray-park.md
+++ b/content/locations/bray-park.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Bray Park"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Tweed Valley."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Bray Park. Same or next-day support across Tweed Valley.
 

--- a/content/locations/brays-creek.md
+++ b/content/locations/brays-creek.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Brays Creek"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Tweed Valley."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Brays Creek. Same or next-day support across Tweed Valley.
 

--- a/content/locations/brooklet.md
+++ b/content/locations/brooklet.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Brooklet"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Ballina Shire."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Brooklet. Same or next-day support across Ballina Shire.
 

--- a/content/locations/brunswick-heads.md
+++ b/content/locations/brunswick-heads.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Brunswick Heads"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Byron Shire."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Brunswick Heads. Same or next-day support across Byron Shire.
 

--- a/content/locations/bungalora.md
+++ b/content/locations/bungalora.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Bungalora"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Tweed Valley."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Bungalora. Same or next-day support across Tweed Valley.
 

--- a/content/locations/burringbar.md
+++ b/content/locations/burringbar.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Burringbar"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Tweed Valley."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Burringbar. Same or next-day support across Tweed Valley.
 

--- a/content/locations/byangum.md
+++ b/content/locations/byangum.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Byangum"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Tweed Valley."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Byangum. Same or next-day support across Tweed Valley.
 

--- a/content/locations/byron-bay.md
+++ b/content/locations/byron-bay.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Byron Bay"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Byron Shire."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Byron Bay. Same or next-day support across Byron Shire.
 

--- a/content/locations/byrrill-creek.md
+++ b/content/locations/byrrill-creek.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Byrrill Creek"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Tweed Valley."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Byrrill Creek. Same or next-day support across Tweed Valley.
 

--- a/content/locations/cabarita-beach.md
+++ b/content/locations/cabarita-beach.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Cabarita Beach"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Tweed Coast."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Cabarita Beach. Same or next-day support across Tweed Coast.
 

--- a/content/locations/cabbage-tree-island.md
+++ b/content/locations/cabbage-tree-island.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Cabbage Tree Island"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Ballina Shire."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Cabbage Tree Island. Same or next-day support across Ballina Shire.
 

--- a/content/locations/caniaba.md
+++ b/content/locations/caniaba.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Caniaba"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Lismore Region."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Caniaba. Same or next-day support across Lismore Region.
 

--- a/content/locations/carool.md
+++ b/content/locations/carool.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Carool"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Tweed Valley."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Carool. Same or next-day support across Tweed Valley.
 

--- a/content/locations/casuarina.md
+++ b/content/locations/casuarina.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Casuarina"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Tweed Coast."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Casuarina. Same or next-day support across Tweed Coast.
 

--- a/content/locations/cedar-creek.md
+++ b/content/locations/cedar-creek.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Cedar Creek"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Tweed Valley."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Cedar Creek. Same or next-day support across Tweed Valley.
 

--- a/content/locations/chilcotts-grass.md
+++ b/content/locations/chilcotts-grass.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Chilcotts Grass"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Lismore Region."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Chilcotts Grass. Same or next-day support across Lismore Region.
 

--- a/content/locations/chinderah.md
+++ b/content/locations/chinderah.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Chinderah"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Tweed Coast."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Chinderah. Same or next-day support across Tweed Coast.
 

--- a/content/locations/chowan-creek.md
+++ b/content/locations/chowan-creek.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Chowan Creek"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Tweed Valley."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Chowan Creek. Same or next-day support across Tweed Valley.
 

--- a/content/locations/clothiers-creek.md
+++ b/content/locations/clothiers-creek.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Clothiers Creek"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Tweed Valley."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Clothiers Creek. Same or next-day support across Tweed Valley.
 

--- a/content/locations/clunes.md
+++ b/content/locations/clunes.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Clunes"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Lismore Region."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Clunes. Same or next-day support across Lismore Region.
 

--- a/content/locations/cobaki-lakes.md
+++ b/content/locations/cobaki-lakes.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Cobaki Lakes"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Tweed Coast."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Cobaki Lakes. Same or next-day support across Tweed Coast.
 

--- a/content/locations/cobaki.md
+++ b/content/locations/cobaki.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Cobaki"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Tweed Coast."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Cobaki. Same or next-day support across Tweed Coast.
 

--- a/content/locations/commissioners-creek.md
+++ b/content/locations/commissioners-creek.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Commissioners Creek"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Tweed Valley."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Commissioners Creek. Same or next-day support across Tweed Valley.
 

--- a/content/locations/condong.md
+++ b/content/locations/condong.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Condong"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Tweed Valley."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Condong. Same or next-day support across Tweed Valley.
 

--- a/content/locations/coopers-shoot.md
+++ b/content/locations/coopers-shoot.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Coopers Shoot"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Byron Shire."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Coopers Shoot. Same or next-day support across Byron Shire.
 

--- a/content/locations/coorabell.md
+++ b/content/locations/coorabell.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Coorabell"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Byron Shire."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Coorabell. Same or next-day support across Byron Shire.
 

--- a/content/locations/crabbes-creek.md
+++ b/content/locations/crabbes-creek.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Crabbes Creek"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Tweed Valley."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Crabbes Creek. Same or next-day support across Tweed Valley.
 

--- a/content/locations/crystal-creek.md
+++ b/content/locations/crystal-creek.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Crystal Creek"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Tweed Valley."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Crystal Creek. Same or next-day support across Tweed Valley.
 

--- a/content/locations/cudgen.md
+++ b/content/locations/cudgen.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Cudgen"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Tweed Valley."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Cudgen. Same or next-day support across Tweed Valley.
 

--- a/content/locations/cudgera-creek.md
+++ b/content/locations/cudgera-creek.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Cudgera Creek"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Tweed Valley."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Cudgera Creek. Same or next-day support across Tweed Valley.
 

--- a/content/locations/cumbalum.md
+++ b/content/locations/cumbalum.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Cumbalum"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Ballina Shire."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Cumbalum. Same or next-day support across Ballina Shire.
 

--- a/content/locations/dalwood.md
+++ b/content/locations/dalwood.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Dalwood"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Ballina Shire."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Dalwood. Same or next-day support across Ballina Shire.
 

--- a/content/locations/doon-doon.md
+++ b/content/locations/doon-doon.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Doon Doon"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Tweed Valley."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Doon Doon. Same or next-day support across Tweed Valley.
 

--- a/content/locations/dulguigan.md
+++ b/content/locations/dulguigan.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Dulguigan"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Tweed Valley."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Dulguigan. Same or next-day support across Tweed Valley.
 

--- a/content/locations/dungay.md
+++ b/content/locations/dungay.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Dungay"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Tweed Valley."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Dungay. Same or next-day support across Tweed Valley.
 

--- a/content/locations/dunoon.md
+++ b/content/locations/dunoon.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Dunoon"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Lismore Region."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Dunoon. Same or next-day support across Lismore Region.
 

--- a/content/locations/duranbah.md
+++ b/content/locations/duranbah.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Duranbah"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Tweed Valley."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Duranbah. Same or next-day support across Tweed Valley.
 

--- a/content/locations/duroby.md
+++ b/content/locations/duroby.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Duroby"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Tweed Valley."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Duroby. Same or next-day support across Tweed Valley.
 

--- a/content/locations/east-ballina.md
+++ b/content/locations/east-ballina.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in East Ballina"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Ballina Shire."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in East Ballina. Same or next-day support across Ballina Shire.
 

--- a/content/locations/east-lismore.md
+++ b/content/locations/east-lismore.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in East Lismore"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Lismore Region."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in East Lismore. Same or next-day support across Lismore Region.
 

--- a/content/locations/eltham.md
+++ b/content/locations/eltham.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Eltham"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Lismore Region."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Eltham. Same or next-day support across Lismore Region.
 

--- a/content/locations/empire-vale.md
+++ b/content/locations/empire-vale.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Empire Vale"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Ballina Shire."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Empire Vale. Same or next-day support across Ballina Shire.
 

--- a/content/locations/eungella.md
+++ b/content/locations/eungella.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Eungella"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Tweed Valley."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Eungella. Same or next-day support across Tweed Valley.
 

--- a/content/locations/eviron.md
+++ b/content/locations/eviron.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Eviron"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Tweed Valley."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Eviron. Same or next-day support across Tweed Valley.
 

--- a/content/locations/ewingsdale.md
+++ b/content/locations/ewingsdale.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Ewingsdale"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Byron Shire."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Ewingsdale. Same or next-day support across Byron Shire.
 

--- a/content/locations/farrants-hill.md
+++ b/content/locations/farrants-hill.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Farrants Hill"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Tweed Valley."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Farrants Hill. Same or next-day support across Tweed Valley.
 

--- a/content/locations/federal.md
+++ b/content/locations/federal.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Federal"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Byron Shire."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Federal. Same or next-day support across Byron Shire.
 

--- a/content/locations/fernleigh.md
+++ b/content/locations/fernleigh.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Fernleigh"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Ballina Shire."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Fernleigh. Same or next-day support across Ballina Shire.
 

--- a/content/locations/fernvale.md
+++ b/content/locations/fernvale.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Fernvale"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Tweed Valley."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Fernvale. Same or next-day support across Tweed Valley.
 

--- a/content/locations/fingal-head.md
+++ b/content/locations/fingal-head.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Fingal Head"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Tweed Coast."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Fingal Head. Same or next-day support across Tweed Coast.
 

--- a/content/locations/girards-hill.md
+++ b/content/locations/girards-hill.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Girards Hill"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Lismore Region."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Girards Hill. Same or next-day support across Lismore Region.
 

--- a/content/locations/glengarrie.md
+++ b/content/locations/glengarrie.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Glengarrie"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Tweed Valley."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Glengarrie. Same or next-day support across Tweed Valley.
 

--- a/content/locations/goonellabah.md
+++ b/content/locations/goonellabah.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Goonellabah"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Lismore Region."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Goonellabah. Same or next-day support across Lismore Region.
 

--- a/content/locations/goonengerry.md
+++ b/content/locations/goonengerry.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Goonengerry"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Byron Shire."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Goonengerry. Same or next-day support across Byron Shire.
 

--- a/content/locations/hastings-point.md
+++ b/content/locations/hastings-point.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Hastings Point"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Tweed Coast."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Hastings Point. Same or next-day support across Tweed Coast.
 

--- a/content/locations/hayters-hill.md
+++ b/content/locations/hayters-hill.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Hayters Hill"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Byron Shire."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Hayters Hill. Same or next-day support across Byron Shire.
 

--- a/content/locations/hopkins-creek.md
+++ b/content/locations/hopkins-creek.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Hopkins Creek"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Tweed Valley."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Hopkins Creek. Same or next-day support across Tweed Valley.
 

--- a/content/locations/huonbrook.md
+++ b/content/locations/huonbrook.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Huonbrook"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Byron Shire."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Huonbrook. Same or next-day support across Byron Shire.
 

--- a/content/locations/kielvale.md
+++ b/content/locations/kielvale.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Kielvale"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Tweed Valley."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Kielvale. Same or next-day support across Tweed Valley.
 

--- a/content/locations/kings-forest.md
+++ b/content/locations/kings-forest.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Kings Forest"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Tweed Coast."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Kings Forest. Same or next-day support across Tweed Coast.
 

--- a/content/locations/kingscliff.md
+++ b/content/locations/kingscliff.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Kingscliff"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Tweed Coast."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Kingscliff. Same or next-day support across Tweed Coast.
 

--- a/content/locations/knockrow.md
+++ b/content/locations/knockrow.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Knockrow"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Ballina Shire."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Knockrow. Same or next-day support across Ballina Shire.
 

--- a/content/locations/koonyum-range.md
+++ b/content/locations/koonyum-range.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Koonyum Range"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Byron Shire."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Koonyum Range. Same or next-day support across Byron Shire.
 

--- a/content/locations/kunghur-creek.md
+++ b/content/locations/kunghur-creek.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Kunghur Creek"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Tweed Valley."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Kunghur Creek. Same or next-day support across Tweed Valley.
 

--- a/content/locations/kunghur.md
+++ b/content/locations/kunghur.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Kunghur"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Tweed Valley."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Kunghur. Same or next-day support across Tweed Valley.
 

--- a/content/locations/kynnumboon.md
+++ b/content/locations/kynnumboon.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Kynnumboon"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Tweed Valley."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Kynnumboon. Same or next-day support across Tweed Valley.
 

--- a/content/locations/lennox-head.md
+++ b/content/locations/lennox-head.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Lennox Head"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Ballina Shire."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Lennox Head. Same or next-day support across Ballina Shire.
 

--- a/content/locations/limpinwood.md
+++ b/content/locations/limpinwood.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Limpinwood"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Tweed Valley."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Limpinwood. Same or next-day support across Tweed Valley.
 

--- a/content/locations/lismore-heights.md
+++ b/content/locations/lismore-heights.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Lismore Heights"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Lismore Region."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Lismore Heights. Same or next-day support across Lismore Region.
 

--- a/content/locations/lismore.md
+++ b/content/locations/lismore.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Lismore"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Lismore Region."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Lismore. Same or next-day support across Lismore Region.
 

--- a/content/locations/loftville.md
+++ b/content/locations/loftville.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Loftville"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Lismore Region."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Loftville. Same or next-day support across Lismore Region.
 

--- a/content/locations/lynwood.md
+++ b/content/locations/lynwood.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Lynwood"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Ballina Shire."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Lynwood. Same or next-day support across Ballina Shire.
 

--- a/content/locations/main-arm.md
+++ b/content/locations/main-arm.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Main Arm"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Byron Shire."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Main Arm. Same or next-day support across Byron Shire.
 

--- a/content/locations/mcleans-ridges.md
+++ b/content/locations/mcleans-ridges.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in McLeans Ridges"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Ballina Shire."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in McLeans Ridges. Same or next-day support across Ballina Shire.
 

--- a/content/locations/mcleods-shoot.md
+++ b/content/locations/mcleods-shoot.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in McLeods Shoot"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Byron Shire."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in McLeods Shoot. Same or next-day support across Byron Shire.
 

--- a/content/locations/meerschaum-vale.md
+++ b/content/locations/meerschaum-vale.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Meerschaum Vale"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Ballina Shire."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Meerschaum Vale. Same or next-day support across Ballina Shire.
 

--- a/content/locations/middle-pocket.md
+++ b/content/locations/middle-pocket.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Middle Pocket"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Byron Shire."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Middle Pocket. Same or next-day support across Byron Shire.
 

--- a/content/locations/midginbil.md
+++ b/content/locations/midginbil.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Midginbil"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Tweed Valley."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Midginbil. Same or next-day support across Tweed Valley.
 

--- a/content/locations/modanville.md
+++ b/content/locations/modanville.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Modanville"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Lismore Region."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Modanville. Same or next-day support across Lismore Region.
 

--- a/content/locations/mooball.md
+++ b/content/locations/mooball.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Mooball"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Tweed Valley."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Mooball. Same or next-day support across Tweed Valley.
 

--- a/content/locations/mount-burrell.md
+++ b/content/locations/mount-burrell.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Mount Burrell"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Tweed Valley."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Mount Burrell. Same or next-day support across Tweed Valley.
 

--- a/content/locations/mullumbimby-creek.md
+++ b/content/locations/mullumbimby-creek.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Mullumbimby Creek"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Byron Shire."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Mullumbimby Creek. Same or next-day support across Byron Shire.
 

--- a/content/locations/mullumbimby.md
+++ b/content/locations/mullumbimby.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Mullumbimby"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Byron Shire."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Mullumbimby. Same or next-day support across Byron Shire.
 

--- a/content/locations/murwillumbah.md
+++ b/content/locations/murwillumbah.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Murwillumbah"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Tweed Valley."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Murwillumbah. Same or next-day support across Tweed Valley.
 

--- a/content/locations/nashua.md
+++ b/content/locations/nashua.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Nashua"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Byron Shire."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Nashua. Same or next-day support across Byron Shire.
 

--- a/content/locations/new-brighton.md
+++ b/content/locations/new-brighton.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in New Brighton"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Byron Shire."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in New Brighton. Same or next-day support across Byron Shire.
 

--- a/content/locations/newrybar.md
+++ b/content/locations/newrybar.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Newrybar"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Ballina Shire."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Newrybar. Same or next-day support across Ballina Shire.
 

--- a/content/locations/nobbys-creek.md
+++ b/content/locations/nobbys-creek.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Nobbys Creek"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Tweed Valley."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Nobbys Creek. Same or next-day support across Tweed Valley.
 

--- a/content/locations/north-lismore.md
+++ b/content/locations/north-lismore.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in North Lismore"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Lismore Region."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in North Lismore. Same or next-day support across Lismore Region.
 

--- a/content/locations/north-tumbulgum.md
+++ b/content/locations/north-tumbulgum.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in North Tumbulgum"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Tweed Valley."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in North Tumbulgum. Same or next-day support across Tweed Valley.
 

--- a/content/locations/ocean-shores.md
+++ b/content/locations/ocean-shores.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Ocean Shores"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Byron Shire."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Ocean Shores. Same or next-day support across Byron Shire.
 

--- a/content/locations/palmvale.md
+++ b/content/locations/palmvale.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Palmvale"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Tweed Valley."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Palmvale. Same or next-day support across Tweed Valley.
 

--- a/content/locations/palmwoods.md
+++ b/content/locations/palmwoods.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Palmwoods"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Byron Shire."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Palmwoods. Same or next-day support across Byron Shire.
 

--- a/content/locations/patchs-beach.md
+++ b/content/locations/patchs-beach.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Patchs Beach"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Ballina Shire."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Patchs Beach. Same or next-day support across Ballina Shire.
 

--- a/content/locations/pearces-creek.md
+++ b/content/locations/pearces-creek.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Pearces Creek"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Ballina Shire."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Pearces Creek. Same or next-day support across Ballina Shire.
 

--- a/content/locations/piggabeen.md
+++ b/content/locations/piggabeen.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Piggabeen"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Tweed Coast."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Piggabeen. Same or next-day support across Tweed Coast.
 

--- a/content/locations/pimlico.md
+++ b/content/locations/pimlico.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Pimlico"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Ballina Shire."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Pimlico. Same or next-day support across Ballina Shire.
 

--- a/content/locations/possum-creek.md
+++ b/content/locations/possum-creek.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Possum Creek"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Byron Shire."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Possum Creek. Same or next-day support across Byron Shire.
 

--- a/content/locations/pottsville.md
+++ b/content/locations/pottsville.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Pottsville"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Tweed Coast."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Pottsville. Same or next-day support across Tweed Coast.
 

--- a/content/locations/reserve-creek.md
+++ b/content/locations/reserve-creek.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Reserve Creek"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Tweed Valley."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Reserve Creek. Same or next-day support across Tweed Valley.
 

--- a/content/locations/richmond-hill.md
+++ b/content/locations/richmond-hill.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Richmond Hill"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Lismore Region."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Richmond Hill. Same or next-day support across Lismore Region.
 

--- a/content/locations/round-mountain.md
+++ b/content/locations/round-mountain.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Round Mountain"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Tweed Valley."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Round Mountain. Same or next-day support across Tweed Valley.
 

--- a/content/locations/rous-mill.md
+++ b/content/locations/rous-mill.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Rous Mill"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Ballina Shire."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Rous Mill. Same or next-day support across Ballina Shire.
 

--- a/content/locations/rous.md
+++ b/content/locations/rous.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Rous"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Ballina Shire."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Rous. Same or next-day support across Ballina Shire.
 

--- a/content/locations/rowlands-creek.md
+++ b/content/locations/rowlands-creek.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Rowlands Creek"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Tweed Valley."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Rowlands Creek. Same or next-day support across Tweed Valley.
 

--- a/content/locations/skennars-head.md
+++ b/content/locations/skennars-head.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Skennars Head"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Ballina Shire."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Skennars Head. Same or next-day support across Ballina Shire.
 

--- a/content/locations/skinners-shoot.md
+++ b/content/locations/skinners-shoot.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Skinners Shoot"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Byron Shire."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Skinners Shoot. Same or next-day support across Byron Shire.
 

--- a/content/locations/sleepy-hollow.md
+++ b/content/locations/sleepy-hollow.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Sleepy Hollow"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Tweed Valley."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Sleepy Hollow. Same or next-day support across Tweed Valley.
 

--- a/content/locations/smiths-creek.md
+++ b/content/locations/smiths-creek.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Smiths Creek"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Tweed Valley."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Smiths Creek. Same or next-day support across Tweed Valley.
 

--- a/content/locations/south-ballina.md
+++ b/content/locations/south-ballina.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in South Ballina"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Ballina Shire."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in South Ballina. Same or next-day support across Ballina Shire.
 

--- a/content/locations/south-golden-beach.md
+++ b/content/locations/south-golden-beach.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in South Golden Beach"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Byron Shire."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in South Golden Beach. Same or next-day support across Byron Shire.
 

--- a/content/locations/south-lismore.md
+++ b/content/locations/south-lismore.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in South Lismore"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Lismore Region."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in South Lismore. Same or next-day support across Lismore Region.
 

--- a/content/locations/south-murwillumbah.md
+++ b/content/locations/south-murwillumbah.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in South Murwillumbah"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Tweed Valley."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in South Murwillumbah. Same or next-day support across Tweed Valley.
 

--- a/content/locations/stokers-siding.md
+++ b/content/locations/stokers-siding.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Stokers Siding"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Tweed Valley."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Stokers Siding. Same or next-day support across Tweed Valley.
 

--- a/content/locations/suffolk-park.md
+++ b/content/locations/suffolk-park.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Suffolk Park"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Byron Shire."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Suffolk Park. Same or next-day support across Byron Shire.
 

--- a/content/locations/talofa.md
+++ b/content/locations/talofa.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Talofa"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Byron Shire."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Talofa. Same or next-day support across Byron Shire.
 

--- a/content/locations/tanglewood.md
+++ b/content/locations/tanglewood.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Tanglewood"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Tweed Valley."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Tanglewood. Same or next-day support across Tweed Valley.
 

--- a/content/locations/terranora.md
+++ b/content/locations/terranora.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Terranora"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Tweed Coast."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Terranora. Same or next-day support across Tweed Coast.
 

--- a/content/locations/teven.md
+++ b/content/locations/teven.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Teven"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Ballina Shire."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Teven. Same or next-day support across Ballina Shire.
 

--- a/content/locations/the-pocket.md
+++ b/content/locations/the-pocket.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in The Pocket"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Byron Shire."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in The Pocket. Same or next-day support across Byron Shire.
 

--- a/content/locations/tintenbar.md
+++ b/content/locations/tintenbar.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Tintenbar"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Ballina Shire."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Tintenbar. Same or next-day support across Ballina Shire.
 

--- a/content/locations/tomewin.md
+++ b/content/locations/tomewin.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Tomewin"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Tweed Valley."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Tomewin. Same or next-day support across Tweed Valley.
 

--- a/content/locations/tregeagle.md
+++ b/content/locations/tregeagle.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Tregeagle"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Lismore Region."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Tregeagle. Same or next-day support across Lismore Region.
 

--- a/content/locations/tucki-tucki.md
+++ b/content/locations/tucki-tucki.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Tucki Tucki"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Lismore Region."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Tucki Tucki. Same or next-day support across Lismore Region.
 

--- a/content/locations/tumbulgum.md
+++ b/content/locations/tumbulgum.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Tumbulgum"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Tweed Valley."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Tumbulgum. Same or next-day support across Tweed Valley.
 

--- a/content/locations/tweed-heads-south.md
+++ b/content/locations/tweed-heads-south.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Tweed Heads South"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Tweed Coast."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Tweed Heads South. Same or next-day support across Tweed Coast.
 

--- a/content/locations/tweed-heads-west.md
+++ b/content/locations/tweed-heads-west.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Tweed Heads West"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Tweed Coast."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Tweed Heads West. Same or next-day support across Tweed Coast.
 

--- a/content/locations/tweed-heads.md
+++ b/content/locations/tweed-heads.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Tweed Heads"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Tweed Coast."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Tweed Heads. Same or next-day support across Tweed Coast.
 

--- a/content/locations/tyagarah.md
+++ b/content/locations/tyagarah.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Tyagarah"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Byron Shire."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Tyagarah. Same or next-day support across Byron Shire.
 

--- a/content/locations/tyalgum-creek.md
+++ b/content/locations/tyalgum-creek.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Tyalgum Creek"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Tweed Valley."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Tyalgum Creek. Same or next-day support across Tweed Valley.
 

--- a/content/locations/tyalgum.md
+++ b/content/locations/tyalgum.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Tyalgum"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Tweed Valley."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Tyalgum. Same or next-day support across Tweed Valley.
 

--- a/content/locations/tygalgah.md
+++ b/content/locations/tygalgah.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Tygalgah"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Tweed Valley."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Tygalgah. Same or next-day support across Tweed Valley.
 

--- a/content/locations/uki.md
+++ b/content/locations/uki.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Uki"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Tweed Valley."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Uki. Same or next-day support across Tweed Valley.
 

--- a/content/locations/upper-burringbar.md
+++ b/content/locations/upper-burringbar.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Upper Burringbar"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Tweed Valley."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Upper Burringbar. Same or next-day support across Tweed Valley.
 

--- a/content/locations/upper-coopers-creek.md
+++ b/content/locations/upper-coopers-creek.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Upper Coopers Creek"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Byron Shire."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Upper Coopers Creek. Same or next-day support across Byron Shire.
 

--- a/content/locations/upper-crystal-creek.md
+++ b/content/locations/upper-crystal-creek.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Upper Crystal Creek"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Tweed Valley."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Upper Crystal Creek. Same or next-day support across Tweed Valley.
 

--- a/content/locations/upper-duroby.md
+++ b/content/locations/upper-duroby.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Upper Duroby"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Tweed Valley."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Upper Duroby. Same or next-day support across Tweed Valley.
 

--- a/content/locations/upper-main-arm.md
+++ b/content/locations/upper-main-arm.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Upper Main Arm"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Byron Shire."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Upper Main Arm. Same or next-day support across Byron Shire.
 

--- a/content/locations/upper-wilsons-creek.md
+++ b/content/locations/upper-wilsons-creek.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Upper Wilsons Creek"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Byron Shire."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Upper Wilsons Creek. Same or next-day support across Byron Shire.
 

--- a/content/locations/uralba.md
+++ b/content/locations/uralba.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Uralba"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Ballina Shire."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Uralba. Same or next-day support across Ballina Shire.
 

--- a/content/locations/urliup.md
+++ b/content/locations/urliup.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Urliup"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Tweed Valley."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Urliup. Same or next-day support across Tweed Valley.
 

--- a/content/locations/wanganui.md
+++ b/content/locations/wanganui.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Wanganui"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Byron Shire."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Wanganui. Same or next-day support across Byron Shire.
 

--- a/content/locations/wardell.md
+++ b/content/locations/wardell.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Wardell"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Ballina Shire."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Wardell. Same or next-day support across Ballina Shire.
 

--- a/content/locations/wardrop-valley.md
+++ b/content/locations/wardrop-valley.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Wardrop Valley"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Tweed Valley."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Wardrop Valley. Same or next-day support across Tweed Valley.
 

--- a/content/locations/west-ballina.md
+++ b/content/locations/west-ballina.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in West Ballina"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Ballina Shire."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in West Ballina. Same or next-day support across Ballina Shire.
 

--- a/content/locations/wilsons-creek.md
+++ b/content/locations/wilsons-creek.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Wilsons Creek"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Byron Shire."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Wilsons Creek. Same or next-day support across Byron Shire.
 

--- a/content/locations/wollongbar.md
+++ b/content/locations/wollongbar.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Wollongbar"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Ballina Shire."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Wollongbar. Same or next-day support across Ballina Shire.
 

--- a/content/locations/wollumbin-mount-warning.md
+++ b/content/locations/wollumbin-mount-warning.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Wollumbin (Mount Warning)"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Tweed Valley."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Wollumbin (Mount Warning). Same or next-day support across Tweed Valley.
 

--- a/content/locations/wooyung.md
+++ b/content/locations/wooyung.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Wooyung"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Tweed Coast."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Wooyung. Same or next-day support across Tweed Coast.
 

--- a/content/locations/wyrallah.md
+++ b/content/locations/wyrallah.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Wyrallah"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Lismore Region."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Wyrallah. Same or next-day support across Lismore Region.
 

--- a/content/locations/yelgun.md
+++ b/content/locations/yelgun.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Yelgun"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Byron Shire."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Yelgun. Same or next-day support across Byron Shire.
 

--- a/content/locations/zara.md
+++ b/content/locations/zara.md
@@ -14,7 +14,7 @@ h1 = "Local Pest Control in Zara"
 subhead = "Licensed NSW EPA technician providing targeted, low-tox treatments across Tweed Valley."
 +++
 
-# {{< seo.h1 >}}
+{{< seo_h1 >}}
 
 Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Zara. Same or next-day support across Tweed Valley.
 

--- a/layouts/shortcodes/seo_h1.html
+++ b/layouts/shortcodes/seo_h1.html
@@ -1,0 +1,13 @@
+{{- $seo := .Page.Params.seo -}}
+{{- $h1 := .Page.Title -}}
+{{- $subhead := "" -}}
+{{- with $seo }}
+  {{- with .h1 }}{{ $h1 = . }}{{ end -}}
+  {{- with .subhead }}{{ $subhead = . }}{{ end -}}
+{{- end -}}
+{{- if $h1 }}
+<h1>{{ $h1 | htmlEscape }}</h1>
+{{- end }}
+{{- if $subhead }}
+<p class="subhead">{{ $subhead | htmlEscape }}</p>
+{{- end -}}


### PR DESCRIPTION
## Summary
- add a shortcode that renders page headlines from `.Params.seo`
- replace the old `seo.h1` shortcode usage across all location markdown files so the new shortcode can output the `<h1>` markup

## Testing
- hugo --gc --minify

------
https://chatgpt.com/codex/tasks/task_e_68ca02604b3c83259125b6696f98bbe5