### PR TITLE
Update scheduling messaging on service and location pages

### DIFF
--- a/content/locations/_index.md
+++ b/content/locations/_index.md
@@ -12,7 +12,7 @@ answer = "Yes, contact me to see if I can travel to your community."
 
 [[faq]]
 question = "How soon can you visit my area?"
-answer = "I aim to provide same or next-day service where possible."
+answer = "I schedule work around existing runs and will let you know the first available time when you get in touch."
 +++
 
 I provide eco-friendly pest control across the Tweed Coast. Choose your area below.

--- a/content/locations/alstonvale.md
+++ b/content/locations/alstonvale.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Alstonvale | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Alstonvale for homes and businesses. Same or next-day service across Ballina Shire."
+description = "Licensed, eco-conscious pest control in Alstonvale for homes and businesses. Visits are scheduled around regular service runs across Ballina Shire."
 keywords = [
   "Alstonvale pest control",
   "Ballina Shire termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Alstonvale. Same or next-day support across Ballina Shire.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Alstonvale. Support is booked around regular service runs across Ballina Shire.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/alstonville.md
+++ b/content/locations/alstonville.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Alstonville | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Alstonville for homes and businesses. Same or next-day service across Ballina Shire."
+description = "Licensed, eco-conscious pest control in Alstonville for homes and businesses. Visits are scheduled around regular service runs across Ballina Shire."
 keywords = [
   "Alstonville pest control",
   "Ballina Shire termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Alstonville. Same or next-day support across Ballina Shire.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Alstonville. Support is booked around regular service runs across Ballina Shire.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/back-creek.md
+++ b/content/locations/back-creek.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Back Creek | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Back Creek for homes and businesses. Same or next-day service across Tweed Valley."
+description = "Licensed, eco-conscious pest control in Back Creek for homes and businesses. Visits are scheduled around regular service runs across Tweed Valley."
 keywords = [
   "Back Creek pest control",
   "Tweed Valley termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Back Creek. Same or next-day support across Tweed Valley.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Back Creek. Support is booked around regular service runs across Tweed Valley.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/ballina.md
+++ b/content/locations/ballina.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Ballina | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Ballina for homes and businesses. Same or next-day service across Ballina Shire."
+description = "Licensed, eco-conscious pest control in Ballina for homes and businesses. Visits are scheduled around regular service runs across Ballina Shire."
 keywords = [
   "Ballina pest control",
   "Ballina Shire termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Ballina. Same or next-day support across Ballina Shire.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Ballina. Support is booked around regular service runs across Ballina Shire.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/bangalow.md
+++ b/content/locations/bangalow.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Bangalow | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Bangalow for homes and businesses. Same or next-day service across Byron Shire."
+description = "Licensed, eco-conscious pest control in Bangalow for homes and businesses. Visits are scheduled around regular service runs across Byron Shire."
 keywords = [
   "Bangalow pest control",
   "Byron Shire termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Bangalow. Same or next-day support across Byron Shire.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Bangalow. Support is booked around regular service runs across Byron Shire.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/banora-point.md
+++ b/content/locations/banora-point.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Banora Point | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Banora Point for homes and businesses. Same or next-day service across Tweed Coast."
+description = "Licensed, eco-conscious pest control in Banora Point for homes and businesses. Visits are scheduled around regular service runs across Tweed Coast."
 keywords = [
   "Banora Point pest control",
   "Tweed Coast termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Banora Point. Same or next-day support across Tweed Coast.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Banora Point. Support is booked around regular service runs across Tweed Coast.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/bexhill.md
+++ b/content/locations/bexhill.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Bexhill | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Bexhill for homes and businesses. Same or next-day service across Lismore Region."
+description = "Licensed, eco-conscious pest control in Bexhill for homes and businesses. Visits are scheduled around regular service runs across Lismore Region."
 keywords = [
   "Bexhill pest control",
   "Lismore Region termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Bexhill. Same or next-day support across Lismore Region.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Bexhill. Support is booked around regular service runs across Lismore Region.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/bilambil-heights.md
+++ b/content/locations/bilambil-heights.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Bilambil Heights | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Bilambil Heights for homes and businesses. Same or next-day service across Tweed Coast."
+description = "Licensed, eco-conscious pest control in Bilambil Heights for homes and businesses. Visits are scheduled around regular service runs across Tweed Coast."
 keywords = [
   "Bilambil Heights pest control",
   "Tweed Coast termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Bilambil Heights. Same or next-day support across Tweed Coast.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Bilambil Heights. Support is booked around regular service runs across Tweed Coast.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/bilambil.md
+++ b/content/locations/bilambil.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Bilambil | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Bilambil for homes and businesses. Same or next-day service across Tweed Coast."
+description = "Licensed, eco-conscious pest control in Bilambil for homes and businesses. Visits are scheduled around regular service runs across Tweed Coast."
 keywords = [
   "Bilambil pest control",
   "Tweed Coast termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Bilambil. Same or next-day support across Tweed Coast.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Bilambil. Support is booked around regular service runs across Tweed Coast.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/billinudgel.md
+++ b/content/locations/billinudgel.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Billinudgel | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Billinudgel for homes and businesses. Same or next-day service across Byron Shire."
+description = "Licensed, eco-conscious pest control in Billinudgel for homes and businesses. Visits are scheduled around regular service runs across Byron Shire."
 keywords = [
   "Billinudgel pest control",
   "Byron Shire termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Billinudgel. Same or next-day support across Byron Shire.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Billinudgel. Support is booked around regular service runs across Byron Shire.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/binna-burra.md
+++ b/content/locations/binna-burra.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Binna Burra | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Binna Burra for homes and businesses. Same or next-day service across Byron Shire."
+description = "Licensed, eco-conscious pest control in Binna Burra for homes and businesses. Visits are scheduled around regular service runs across Byron Shire."
 keywords = [
   "Binna Burra pest control",
   "Byron Shire termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Binna Burra. Same or next-day support across Byron Shire.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Binna Burra. Support is booked around regular service runs across Byron Shire.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/bogangar.md
+++ b/content/locations/bogangar.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Bogangar | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Bogangar for homes and businesses. Same or next-day service across Tweed Coast."
+description = "Licensed, eco-conscious pest control in Bogangar for homes and businesses. Visits are scheduled around regular service runs across Tweed Coast."
 keywords = [
   "Bogangar pest control",
   "Tweed Coast termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Bogangar. Same or next-day support across Tweed Coast.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Bogangar. Support is booked around regular service runs across Tweed Coast.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/bray-park.md
+++ b/content/locations/bray-park.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Bray Park | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Bray Park for homes and businesses. Same or next-day service across Tweed Valley."
+description = "Licensed, eco-conscious pest control in Bray Park for homes and businesses. Visits are scheduled around regular service runs across Tweed Valley."
 keywords = [
   "Bray Park pest control",
   "Tweed Valley termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Bray Park. Same or next-day support across Tweed Valley.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Bray Park. Support is booked around regular service runs across Tweed Valley.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/brays-creek.md
+++ b/content/locations/brays-creek.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Brays Creek | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Brays Creek for homes and businesses. Same or next-day service across Tweed Valley."
+description = "Licensed, eco-conscious pest control in Brays Creek for homes and businesses. Visits are scheduled around regular service runs across Tweed Valley."
 keywords = [
   "Brays Creek pest control",
   "Tweed Valley termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Brays Creek. Same or next-day support across Tweed Valley.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Brays Creek. Support is booked around regular service runs across Tweed Valley.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/brooklet.md
+++ b/content/locations/brooklet.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Brooklet | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Brooklet for homes and businesses. Same or next-day service across Ballina Shire."
+description = "Licensed, eco-conscious pest control in Brooklet for homes and businesses. Visits are scheduled around regular service runs across Ballina Shire."
 keywords = [
   "Brooklet pest control",
   "Ballina Shire termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Brooklet. Same or next-day support across Ballina Shire.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Brooklet. Support is booked around regular service runs across Ballina Shire.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/brunswick-heads.md
+++ b/content/locations/brunswick-heads.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Brunswick Heads | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Brunswick Heads for homes and businesses. Same or next-day service across Byron Shire."
+description = "Licensed, eco-conscious pest control in Brunswick Heads for homes and businesses. Visits are scheduled around regular service runs across Byron Shire."
 keywords = [
   "Brunswick Heads pest control",
   "Byron Shire termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Brunswick Heads. Same or next-day support across Byron Shire.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Brunswick Heads. Support is booked around regular service runs across Byron Shire.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/bungalora.md
+++ b/content/locations/bungalora.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Bungalora | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Bungalora for homes and businesses. Same or next-day service across Tweed Valley."
+description = "Licensed, eco-conscious pest control in Bungalora for homes and businesses. Visits are scheduled around regular service runs across Tweed Valley."
 keywords = [
   "Bungalora pest control",
   "Tweed Valley termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Bungalora. Same or next-day support across Tweed Valley.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Bungalora. Support is booked around regular service runs across Tweed Valley.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/burringbar.md
+++ b/content/locations/burringbar.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Burringbar | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Burringbar for homes and businesses. Same or next-day service across Tweed Valley."
+description = "Licensed, eco-conscious pest control in Burringbar for homes and businesses. Visits are scheduled around regular service runs across Tweed Valley."
 keywords = [
   "Burringbar pest control",
   "Tweed Valley termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Burringbar. Same or next-day support across Tweed Valley.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Burringbar. Support is booked around regular service runs across Tweed Valley.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/byangum.md
+++ b/content/locations/byangum.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Byangum | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Byangum for homes and businesses. Same or next-day service across Tweed Valley."
+description = "Licensed, eco-conscious pest control in Byangum for homes and businesses. Visits are scheduled around regular service runs across Tweed Valley."
 keywords = [
   "Byangum pest control",
   "Tweed Valley termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Byangum. Same or next-day support across Tweed Valley.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Byangum. Support is booked around regular service runs across Tweed Valley.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/byron-bay.md
+++ b/content/locations/byron-bay.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Byron Bay | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Byron Bay for homes and businesses. Same or next-day service across Byron Shire."
+description = "Licensed, eco-conscious pest control in Byron Bay for homes and businesses. Visits are scheduled around regular service runs across Byron Shire."
 keywords = [
   "Byron Bay pest control",
   "Byron Shire termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Byron Bay. Same or next-day support across Byron Shire.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Byron Bay. Support is booked around regular service runs across Byron Shire.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/byrrill-creek.md
+++ b/content/locations/byrrill-creek.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Byrrill Creek | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Byrrill Creek for homes and businesses. Same or next-day service across Tweed Valley."
+description = "Licensed, eco-conscious pest control in Byrrill Creek for homes and businesses. Visits are scheduled around regular service runs across Tweed Valley."
 keywords = [
   "Byrrill Creek pest control",
   "Tweed Valley termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Byrrill Creek. Same or next-day support across Tweed Valley.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Byrrill Creek. Support is booked around regular service runs across Tweed Valley.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/cabarita-beach.md
+++ b/content/locations/cabarita-beach.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Cabarita Beach | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Cabarita Beach for homes and businesses. Same or next-day service across Tweed Coast."
+description = "Licensed, eco-conscious pest control in Cabarita Beach for homes and businesses. Visits are scheduled around regular service runs across Tweed Coast."
 keywords = [
   "Cabarita Beach pest control",
   "Tweed Coast termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Cabarita Beach. Same or next-day support across Tweed Coast.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Cabarita Beach. Support is booked around regular service runs across Tweed Coast.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/cabbage-tree-island.md
+++ b/content/locations/cabbage-tree-island.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Cabbage Tree Island | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Cabbage Tree Island for homes and businesses. Same or next-day service across Ballina Shire."
+description = "Licensed, eco-conscious pest control in Cabbage Tree Island for homes and businesses. Visits are scheduled around regular service runs across Ballina Shire."
 keywords = [
   "Cabbage Tree Island pest control",
   "Ballina Shire termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Cabbage Tree Island. Same or next-day support across Ballina Shire.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Cabbage Tree Island. Support is booked around regular service runs across Ballina Shire.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/caniaba.md
+++ b/content/locations/caniaba.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Caniaba | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Caniaba for homes and businesses. Same or next-day service across Lismore Region."
+description = "Licensed, eco-conscious pest control in Caniaba for homes and businesses. Visits are scheduled around regular service runs across Lismore Region."
 keywords = [
   "Caniaba pest control",
   "Lismore Region termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Caniaba. Same or next-day support across Lismore Region.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Caniaba. Support is booked around regular service runs across Lismore Region.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/carool.md
+++ b/content/locations/carool.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Carool | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Carool for homes and businesses. Same or next-day service across Tweed Valley."
+description = "Licensed, eco-conscious pest control in Carool for homes and businesses. Visits are scheduled around regular service runs across Tweed Valley."
 keywords = [
   "Carool pest control",
   "Tweed Valley termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Carool. Same or next-day support across Tweed Valley.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Carool. Support is booked around regular service runs across Tweed Valley.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/casuarina.md
+++ b/content/locations/casuarina.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Casuarina | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Casuarina for homes and businesses. Same or next-day service across Tweed Coast."
+description = "Licensed, eco-conscious pest control in Casuarina for homes and businesses. Visits are scheduled around regular service runs across Tweed Coast."
 keywords = [
   "Casuarina pest control",
   "Tweed Coast termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Casuarina. Same or next-day support across Tweed Coast.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Casuarina. Support is booked around regular service runs across Tweed Coast.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/cedar-creek.md
+++ b/content/locations/cedar-creek.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Cedar Creek | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Cedar Creek for homes and businesses. Same or next-day service across Tweed Valley."
+description = "Licensed, eco-conscious pest control in Cedar Creek for homes and businesses. Visits are scheduled around regular service runs across Tweed Valley."
 keywords = [
   "Cedar Creek pest control",
   "Tweed Valley termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Cedar Creek. Same or next-day support across Tweed Valley.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Cedar Creek. Support is booked around regular service runs across Tweed Valley.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/chilcotts-grass.md
+++ b/content/locations/chilcotts-grass.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Chilcotts Grass | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Chilcotts Grass for homes and businesses. Same or next-day service across Lismore Region."
+description = "Licensed, eco-conscious pest control in Chilcotts Grass for homes and businesses. Visits are scheduled around regular service runs across Lismore Region."
 keywords = [
   "Chilcotts Grass pest control",
   "Lismore Region termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Chilcotts Grass. Same or next-day support across Lismore Region.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Chilcotts Grass. Support is booked around regular service runs across Lismore Region.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/chinderah.md
+++ b/content/locations/chinderah.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Chinderah | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Chinderah for homes and businesses. Same or next-day service across Tweed Coast."
+description = "Licensed, eco-conscious pest control in Chinderah for homes and businesses. Visits are scheduled around regular service runs across Tweed Coast."
 keywords = [
   "Chinderah pest control",
   "Tweed Coast termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Chinderah. Same or next-day support across Tweed Coast.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Chinderah. Support is booked around regular service runs across Tweed Coast.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/chowan-creek.md
+++ b/content/locations/chowan-creek.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Chowan Creek | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Chowan Creek for homes and businesses. Same or next-day service across Tweed Valley."
+description = "Licensed, eco-conscious pest control in Chowan Creek for homes and businesses. Visits are scheduled around regular service runs across Tweed Valley."
 keywords = [
   "Chowan Creek pest control",
   "Tweed Valley termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Chowan Creek. Same or next-day support across Tweed Valley.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Chowan Creek. Support is booked around regular service runs across Tweed Valley.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/clothiers-creek.md
+++ b/content/locations/clothiers-creek.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Clothiers Creek | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Clothiers Creek for homes and businesses. Same or next-day service across Tweed Valley."
+description = "Licensed, eco-conscious pest control in Clothiers Creek for homes and businesses. Visits are scheduled around regular service runs across Tweed Valley."
 keywords = [
   "Clothiers Creek pest control",
   "Tweed Valley termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Clothiers Creek. Same or next-day support across Tweed Valley.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Clothiers Creek. Support is booked around regular service runs across Tweed Valley.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/clunes.md
+++ b/content/locations/clunes.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Clunes | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Clunes for homes and businesses. Same or next-day service across Lismore Region."
+description = "Licensed, eco-conscious pest control in Clunes for homes and businesses. Visits are scheduled around regular service runs across Lismore Region."
 keywords = [
   "Clunes pest control",
   "Lismore Region termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Clunes. Same or next-day support across Lismore Region.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Clunes. Support is booked around regular service runs across Lismore Region.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/cobaki-lakes.md
+++ b/content/locations/cobaki-lakes.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Cobaki Lakes | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Cobaki Lakes for homes and businesses. Same or next-day service across Tweed Coast."
+description = "Licensed, eco-conscious pest control in Cobaki Lakes for homes and businesses. Visits are scheduled around regular service runs across Tweed Coast."
 keywords = [
   "Cobaki Lakes pest control",
   "Tweed Coast termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Cobaki Lakes. Same or next-day support across Tweed Coast.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Cobaki Lakes. Support is booked around regular service runs across Tweed Coast.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/cobaki.md
+++ b/content/locations/cobaki.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Cobaki | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Cobaki for homes and businesses. Same or next-day service across Tweed Coast."
+description = "Licensed, eco-conscious pest control in Cobaki for homes and businesses. Visits are scheduled around regular service runs across Tweed Coast."
 keywords = [
   "Cobaki pest control",
   "Tweed Coast termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Cobaki. Same or next-day support across Tweed Coast.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Cobaki. Support is booked around regular service runs across Tweed Coast.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/commissioners-creek.md
+++ b/content/locations/commissioners-creek.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Commissioners Creek | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Commissioners Creek for homes and businesses. Same or next-day service across Tweed Valley."
+description = "Licensed, eco-conscious pest control in Commissioners Creek for homes and businesses. Visits are scheduled around regular service runs across Tweed Valley."
 keywords = [
   "Commissioners Creek pest control",
   "Tweed Valley termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Commissioners Creek. Same or next-day support across Tweed Valley.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Commissioners Creek. Support is booked around regular service runs across Tweed Valley.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/condong.md
+++ b/content/locations/condong.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Condong | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Condong for homes and businesses. Same or next-day service across Tweed Valley."
+description = "Licensed, eco-conscious pest control in Condong for homes and businesses. Visits are scheduled around regular service runs across Tweed Valley."
 keywords = [
   "Condong pest control",
   "Tweed Valley termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Condong. Same or next-day support across Tweed Valley.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Condong. Support is booked around regular service runs across Tweed Valley.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/coopers-shoot.md
+++ b/content/locations/coopers-shoot.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Coopers Shoot | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Coopers Shoot for homes and businesses. Same or next-day service across Byron Shire."
+description = "Licensed, eco-conscious pest control in Coopers Shoot for homes and businesses. Visits are scheduled around regular service runs across Byron Shire."
 keywords = [
   "Coopers Shoot pest control",
   "Byron Shire termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Coopers Shoot. Same or next-day support across Byron Shire.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Coopers Shoot. Support is booked around regular service runs across Byron Shire.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/coorabell.md
+++ b/content/locations/coorabell.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Coorabell | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Coorabell for homes and businesses. Same or next-day service across Byron Shire."
+description = "Licensed, eco-conscious pest control in Coorabell for homes and businesses. Visits are scheduled around regular service runs across Byron Shire."
 keywords = [
   "Coorabell pest control",
   "Byron Shire termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Coorabell. Same or next-day support across Byron Shire.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Coorabell. Support is booked around regular service runs across Byron Shire.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/crabbes-creek.md
+++ b/content/locations/crabbes-creek.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Crabbes Creek | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Crabbes Creek for homes and businesses. Same or next-day service across Tweed Valley."
+description = "Licensed, eco-conscious pest control in Crabbes Creek for homes and businesses. Visits are scheduled around regular service runs across Tweed Valley."
 keywords = [
   "Crabbes Creek pest control",
   "Tweed Valley termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Crabbes Creek. Same or next-day support across Tweed Valley.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Crabbes Creek. Support is booked around regular service runs across Tweed Valley.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/crystal-creek.md
+++ b/content/locations/crystal-creek.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Crystal Creek | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Crystal Creek for homes and businesses. Same or next-day service across Tweed Valley."
+description = "Licensed, eco-conscious pest control in Crystal Creek for homes and businesses. Visits are scheduled around regular service runs across Tweed Valley."
 keywords = [
   "Crystal Creek pest control",
   "Tweed Valley termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Crystal Creek. Same or next-day support across Tweed Valley.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Crystal Creek. Support is booked around regular service runs across Tweed Valley.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/cudgen.md
+++ b/content/locations/cudgen.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Cudgen | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Cudgen for homes and businesses. Same or next-day service across Tweed Valley."
+description = "Licensed, eco-conscious pest control in Cudgen for homes and businesses. Visits are scheduled around regular service runs across Tweed Valley."
 keywords = [
   "Cudgen pest control",
   "Tweed Valley termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Cudgen. Same or next-day support across Tweed Valley.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Cudgen. Support is booked around regular service runs across Tweed Valley.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/cudgera-creek.md
+++ b/content/locations/cudgera-creek.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Cudgera Creek | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Cudgera Creek for homes and businesses. Same or next-day service across Tweed Valley."
+description = "Licensed, eco-conscious pest control in Cudgera Creek for homes and businesses. Visits are scheduled around regular service runs across Tweed Valley."
 keywords = [
   "Cudgera Creek pest control",
   "Tweed Valley termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Cudgera Creek. Same or next-day support across Tweed Valley.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Cudgera Creek. Support is booked around regular service runs across Tweed Valley.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/cumbalum.md
+++ b/content/locations/cumbalum.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Cumbalum | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Cumbalum for homes and businesses. Same or next-day service across Ballina Shire."
+description = "Licensed, eco-conscious pest control in Cumbalum for homes and businesses. Visits are scheduled around regular service runs across Ballina Shire."
 keywords = [
   "Cumbalum pest control",
   "Ballina Shire termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Cumbalum. Same or next-day support across Ballina Shire.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Cumbalum. Support is booked around regular service runs across Ballina Shire.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/dalwood.md
+++ b/content/locations/dalwood.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Dalwood | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Dalwood for homes and businesses. Same or next-day service across Ballina Shire."
+description = "Licensed, eco-conscious pest control in Dalwood for homes and businesses. Visits are scheduled around regular service runs across Ballina Shire."
 keywords = [
   "Dalwood pest control",
   "Ballina Shire termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Dalwood. Same or next-day support across Ballina Shire.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Dalwood. Support is booked around regular service runs across Ballina Shire.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/doon-doon.md
+++ b/content/locations/doon-doon.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Doon Doon | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Doon Doon for homes and businesses. Same or next-day service across Tweed Valley."
+description = "Licensed, eco-conscious pest control in Doon Doon for homes and businesses. Visits are scheduled around regular service runs across Tweed Valley."
 keywords = [
   "Doon Doon pest control",
   "Tweed Valley termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Doon Doon. Same or next-day support across Tweed Valley.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Doon Doon. Support is booked around regular service runs across Tweed Valley.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/dulguigan.md
+++ b/content/locations/dulguigan.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Dulguigan | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Dulguigan for homes and businesses. Same or next-day service across Tweed Valley."
+description = "Licensed, eco-conscious pest control in Dulguigan for homes and businesses. Visits are scheduled around regular service runs across Tweed Valley."
 keywords = [
   "Dulguigan pest control",
   "Tweed Valley termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Dulguigan. Same or next-day support across Tweed Valley.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Dulguigan. Support is booked around regular service runs across Tweed Valley.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/dungay.md
+++ b/content/locations/dungay.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Dungay | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Dungay for homes and businesses. Same or next-day service across Tweed Valley."
+description = "Licensed, eco-conscious pest control in Dungay for homes and businesses. Visits are scheduled around regular service runs across Tweed Valley."
 keywords = [
   "Dungay pest control",
   "Tweed Valley termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Dungay. Same or next-day support across Tweed Valley.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Dungay. Support is booked around regular service runs across Tweed Valley.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/dunoon.md
+++ b/content/locations/dunoon.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Dunoon | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Dunoon for homes and businesses. Same or next-day service across Lismore Region."
+description = "Licensed, eco-conscious pest control in Dunoon for homes and businesses. Visits are scheduled around regular service runs across Lismore Region."
 keywords = [
   "Dunoon pest control",
   "Lismore Region termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Dunoon. Same or next-day support across Lismore Region.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Dunoon. Support is booked around regular service runs across Lismore Region.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/duranbah.md
+++ b/content/locations/duranbah.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Duranbah | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Duranbah for homes and businesses. Same or next-day service across Tweed Valley."
+description = "Licensed, eco-conscious pest control in Duranbah for homes and businesses. Visits are scheduled around regular service runs across Tweed Valley."
 keywords = [
   "Duranbah pest control",
   "Tweed Valley termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Duranbah. Same or next-day support across Tweed Valley.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Duranbah. Support is booked around regular service runs across Tweed Valley.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/duroby.md
+++ b/content/locations/duroby.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Duroby | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Duroby for homes and businesses. Same or next-day service across Tweed Valley."
+description = "Licensed, eco-conscious pest control in Duroby for homes and businesses. Visits are scheduled around regular service runs across Tweed Valley."
 keywords = [
   "Duroby pest control",
   "Tweed Valley termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Duroby. Same or next-day support across Tweed Valley.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Duroby. Support is booked around regular service runs across Tweed Valley.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/east-ballina.md
+++ b/content/locations/east-ballina.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control East Ballina | Local Pest Co"
-description = "Licensed, eco-conscious pest control in East Ballina for homes and businesses. Same or next-day service across Ballina Shire."
+description = "Licensed, eco-conscious pest control in East Ballina for homes and businesses. Visits are scheduled around regular service runs across Ballina Shire."
 keywords = [
   "East Ballina pest control",
   "Ballina Shire termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in East Ballina. Same or next-day support across Ballina Shire.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in East Ballina. Support is booked around regular service runs across Ballina Shire.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/east-lismore.md
+++ b/content/locations/east-lismore.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control East Lismore | Local Pest Co"
-description = "Licensed, eco-conscious pest control in East Lismore for homes and businesses. Same or next-day service across Lismore Region."
+description = "Licensed, eco-conscious pest control in East Lismore for homes and businesses. Visits are scheduled around regular service runs across Lismore Region."
 keywords = [
   "East Lismore pest control",
   "Lismore Region termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in East Lismore. Same or next-day support across Lismore Region.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in East Lismore. Support is booked around regular service runs across Lismore Region.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/eltham.md
+++ b/content/locations/eltham.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Eltham | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Eltham for homes and businesses. Same or next-day service across Lismore Region."
+description = "Licensed, eco-conscious pest control in Eltham for homes and businesses. Visits are scheduled around regular service runs across Lismore Region."
 keywords = [
   "Eltham pest control",
   "Lismore Region termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Eltham. Same or next-day support across Lismore Region.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Eltham. Support is booked around regular service runs across Lismore Region.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/empire-vale.md
+++ b/content/locations/empire-vale.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Empire Vale | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Empire Vale for homes and businesses. Same or next-day service across Ballina Shire."
+description = "Licensed, eco-conscious pest control in Empire Vale for homes and businesses. Visits are scheduled around regular service runs across Ballina Shire."
 keywords = [
   "Empire Vale pest control",
   "Ballina Shire termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Empire Vale. Same or next-day support across Ballina Shire.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Empire Vale. Support is booked around regular service runs across Ballina Shire.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/eungella.md
+++ b/content/locations/eungella.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Eungella | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Eungella for homes and businesses. Same or next-day service across Tweed Valley."
+description = "Licensed, eco-conscious pest control in Eungella for homes and businesses. Visits are scheduled around regular service runs across Tweed Valley."
 keywords = [
   "Eungella pest control",
   "Tweed Valley termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Eungella. Same or next-day support across Tweed Valley.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Eungella. Support is booked around regular service runs across Tweed Valley.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/eviron.md
+++ b/content/locations/eviron.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Eviron | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Eviron for homes and businesses. Same or next-day service across Tweed Valley."
+description = "Licensed, eco-conscious pest control in Eviron for homes and businesses. Visits are scheduled around regular service runs across Tweed Valley."
 keywords = [
   "Eviron pest control",
   "Tweed Valley termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Eviron. Same or next-day support across Tweed Valley.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Eviron. Support is booked around regular service runs across Tweed Valley.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/ewingsdale.md
+++ b/content/locations/ewingsdale.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Ewingsdale | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Ewingsdale for homes and businesses. Same or next-day service across Byron Shire."
+description = "Licensed, eco-conscious pest control in Ewingsdale for homes and businesses. Visits are scheduled around regular service runs across Byron Shire."
 keywords = [
   "Ewingsdale pest control",
   "Byron Shire termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Ewingsdale. Same or next-day support across Byron Shire.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Ewingsdale. Support is booked around regular service runs across Byron Shire.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/farrants-hill.md
+++ b/content/locations/farrants-hill.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Farrants Hill | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Farrants Hill for homes and businesses. Same or next-day service across Tweed Valley."
+description = "Licensed, eco-conscious pest control in Farrants Hill for homes and businesses. Visits are scheduled around regular service runs across Tweed Valley."
 keywords = [
   "Farrants Hill pest control",
   "Tweed Valley termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Farrants Hill. Same or next-day support across Tweed Valley.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Farrants Hill. Support is booked around regular service runs across Tweed Valley.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/federal.md
+++ b/content/locations/federal.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Federal | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Federal for homes and businesses. Same or next-day service across Byron Shire."
+description = "Licensed, eco-conscious pest control in Federal for homes and businesses. Visits are scheduled around regular service runs across Byron Shire."
 keywords = [
   "Federal pest control",
   "Byron Shire termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Federal. Same or next-day support across Byron Shire.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Federal. Support is booked around regular service runs across Byron Shire.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/fernleigh.md
+++ b/content/locations/fernleigh.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Fernleigh | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Fernleigh for homes and businesses. Same or next-day service across Ballina Shire."
+description = "Licensed, eco-conscious pest control in Fernleigh for homes and businesses. Visits are scheduled around regular service runs across Ballina Shire."
 keywords = [
   "Fernleigh pest control",
   "Ballina Shire termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Fernleigh. Same or next-day support across Ballina Shire.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Fernleigh. Support is booked around regular service runs across Ballina Shire.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/fernvale.md
+++ b/content/locations/fernvale.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Fernvale | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Fernvale for homes and businesses. Same or next-day service across Tweed Valley."
+description = "Licensed, eco-conscious pest control in Fernvale for homes and businesses. Visits are scheduled around regular service runs across Tweed Valley."
 keywords = [
   "Fernvale pest control",
   "Tweed Valley termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Fernvale. Same or next-day support across Tweed Valley.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Fernvale. Support is booked around regular service runs across Tweed Valley.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/fingal-head.md
+++ b/content/locations/fingal-head.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Fingal Head | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Fingal Head for homes and businesses. Same or next-day service across Tweed Coast."
+description = "Licensed, eco-conscious pest control in Fingal Head for homes and businesses. Visits are scheduled around regular service runs across Tweed Coast."
 keywords = [
   "Fingal Head pest control",
   "Tweed Coast termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Fingal Head. Same or next-day support across Tweed Coast.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Fingal Head. Support is booked around regular service runs across Tweed Coast.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/girards-hill.md
+++ b/content/locations/girards-hill.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Girards Hill | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Girards Hill for homes and businesses. Same or next-day service across Lismore Region."
+description = "Licensed, eco-conscious pest control in Girards Hill for homes and businesses. Visits are scheduled around regular service runs across Lismore Region."
 keywords = [
   "Girards Hill pest control",
   "Lismore Region termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Girards Hill. Same or next-day support across Lismore Region.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Girards Hill. Support is booked around regular service runs across Lismore Region.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/glengarrie.md
+++ b/content/locations/glengarrie.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Glengarrie | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Glengarrie for homes and businesses. Same or next-day service across Tweed Valley."
+description = "Licensed, eco-conscious pest control in Glengarrie for homes and businesses. Visits are scheduled around regular service runs across Tweed Valley."
 keywords = [
   "Glengarrie pest control",
   "Tweed Valley termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Glengarrie. Same or next-day support across Tweed Valley.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Glengarrie. Support is booked around regular service runs across Tweed Valley.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/goonellabah.md
+++ b/content/locations/goonellabah.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Goonellabah | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Goonellabah for homes and businesses. Same or next-day service across Lismore Region."
+description = "Licensed, eco-conscious pest control in Goonellabah for homes and businesses. Visits are scheduled around regular service runs across Lismore Region."
 keywords = [
   "Goonellabah pest control",
   "Lismore Region termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Goonellabah. Same or next-day support across Lismore Region.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Goonellabah. Support is booked around regular service runs across Lismore Region.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/goonengerry.md
+++ b/content/locations/goonengerry.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Goonengerry | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Goonengerry for homes and businesses. Same or next-day service across Byron Shire."
+description = "Licensed, eco-conscious pest control in Goonengerry for homes and businesses. Visits are scheduled around regular service runs across Byron Shire."
 keywords = [
   "Goonengerry pest control",
   "Byron Shire termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Goonengerry. Same or next-day support across Byron Shire.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Goonengerry. Support is booked around regular service runs across Byron Shire.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/hastings-point.md
+++ b/content/locations/hastings-point.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Hastings Point | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Hastings Point for homes and businesses. Same or next-day service across Tweed Coast."
+description = "Licensed, eco-conscious pest control in Hastings Point for homes and businesses. Visits are scheduled around regular service runs across Tweed Coast."
 keywords = [
   "Hastings Point pest control",
   "Tweed Coast termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Hastings Point. Same or next-day support across Tweed Coast.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Hastings Point. Support is booked around regular service runs across Tweed Coast.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/hayters-hill.md
+++ b/content/locations/hayters-hill.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Hayters Hill | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Hayters Hill for homes and businesses. Same or next-day service across Byron Shire."
+description = "Licensed, eco-conscious pest control in Hayters Hill for homes and businesses. Visits are scheduled around regular service runs across Byron Shire."
 keywords = [
   "Hayters Hill pest control",
   "Byron Shire termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Hayters Hill. Same or next-day support across Byron Shire.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Hayters Hill. Support is booked around regular service runs across Byron Shire.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/hopkins-creek.md
+++ b/content/locations/hopkins-creek.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Hopkins Creek | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Hopkins Creek for homes and businesses. Same or next-day service across Tweed Valley."
+description = "Licensed, eco-conscious pest control in Hopkins Creek for homes and businesses. Visits are scheduled around regular service runs across Tweed Valley."
 keywords = [
   "Hopkins Creek pest control",
   "Tweed Valley termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Hopkins Creek. Same or next-day support across Tweed Valley.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Hopkins Creek. Support is booked around regular service runs across Tweed Valley.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/huonbrook.md
+++ b/content/locations/huonbrook.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Huonbrook | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Huonbrook for homes and businesses. Same or next-day service across Byron Shire."
+description = "Licensed, eco-conscious pest control in Huonbrook for homes and businesses. Visits are scheduled around regular service runs across Byron Shire."
 keywords = [
   "Huonbrook pest control",
   "Byron Shire termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Huonbrook. Same or next-day support across Byron Shire.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Huonbrook. Support is booked around regular service runs across Byron Shire.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/kielvale.md
+++ b/content/locations/kielvale.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Kielvale | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Kielvale for homes and businesses. Same or next-day service across Tweed Valley."
+description = "Licensed, eco-conscious pest control in Kielvale for homes and businesses. Visits are scheduled around regular service runs across Tweed Valley."
 keywords = [
   "Kielvale pest control",
   "Tweed Valley termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Kielvale. Same or next-day support across Tweed Valley.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Kielvale. Support is booked around regular service runs across Tweed Valley.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/kings-forest.md
+++ b/content/locations/kings-forest.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Kings Forest | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Kings Forest for homes and businesses. Same or next-day service across Tweed Coast."
+description = "Licensed, eco-conscious pest control in Kings Forest for homes and businesses. Visits are scheduled around regular service runs across Tweed Coast."
 keywords = [
   "Kings Forest pest control",
   "Tweed Coast termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Kings Forest. Same or next-day support across Tweed Coast.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Kings Forest. Support is booked around regular service runs across Tweed Coast.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/kingscliff.md
+++ b/content/locations/kingscliff.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Kingscliff | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Kingscliff for homes and businesses. Same or next-day service across Tweed Coast."
+description = "Licensed, eco-conscious pest control in Kingscliff for homes and businesses. Visits are scheduled around regular service runs across Tweed Coast."
 keywords = [
   "Kingscliff pest control",
   "Tweed Coast termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Kingscliff. Same or next-day support across Tweed Coast.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Kingscliff. Support is booked around regular service runs across Tweed Coast.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/knockrow.md
+++ b/content/locations/knockrow.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Knockrow | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Knockrow for homes and businesses. Same or next-day service across Ballina Shire."
+description = "Licensed, eco-conscious pest control in Knockrow for homes and businesses. Visits are scheduled around regular service runs across Ballina Shire."
 keywords = [
   "Knockrow pest control",
   "Ballina Shire termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Knockrow. Same or next-day support across Ballina Shire.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Knockrow. Support is booked around regular service runs across Ballina Shire.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/koonyum-range.md
+++ b/content/locations/koonyum-range.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Koonyum Range | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Koonyum Range for homes and businesses. Same or next-day service across Byron Shire."
+description = "Licensed, eco-conscious pest control in Koonyum Range for homes and businesses. Visits are scheduled around regular service runs across Byron Shire."
 keywords = [
   "Koonyum Range pest control",
   "Byron Shire termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Koonyum Range. Same or next-day support across Byron Shire.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Koonyum Range. Support is booked around regular service runs across Byron Shire.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/kunghur-creek.md
+++ b/content/locations/kunghur-creek.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Kunghur Creek | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Kunghur Creek for homes and businesses. Same or next-day service across Tweed Valley."
+description = "Licensed, eco-conscious pest control in Kunghur Creek for homes and businesses. Visits are scheduled around regular service runs across Tweed Valley."
 keywords = [
   "Kunghur Creek pest control",
   "Tweed Valley termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Kunghur Creek. Same or next-day support across Tweed Valley.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Kunghur Creek. Support is booked around regular service runs across Tweed Valley.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/kunghur.md
+++ b/content/locations/kunghur.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Kunghur | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Kunghur for homes and businesses. Same or next-day service across Tweed Valley."
+description = "Licensed, eco-conscious pest control in Kunghur for homes and businesses. Visits are scheduled around regular service runs across Tweed Valley."
 keywords = [
   "Kunghur pest control",
   "Tweed Valley termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Kunghur. Same or next-day support across Tweed Valley.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Kunghur. Support is booked around regular service runs across Tweed Valley.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/kynnumboon.md
+++ b/content/locations/kynnumboon.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Kynnumboon | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Kynnumboon for homes and businesses. Same or next-day service across Tweed Valley."
+description = "Licensed, eco-conscious pest control in Kynnumboon for homes and businesses. Visits are scheduled around regular service runs across Tweed Valley."
 keywords = [
   "Kynnumboon pest control",
   "Tweed Valley termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Kynnumboon. Same or next-day support across Tweed Valley.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Kynnumboon. Support is booked around regular service runs across Tweed Valley.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/lennox-head.md
+++ b/content/locations/lennox-head.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Lennox Head | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Lennox Head for homes and businesses. Same or next-day service across Ballina Shire."
+description = "Licensed, eco-conscious pest control in Lennox Head for homes and businesses. Visits are scheduled around regular service runs across Ballina Shire."
 keywords = [
   "Lennox Head pest control",
   "Ballina Shire termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Lennox Head. Same or next-day support across Ballina Shire.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Lennox Head. Support is booked around regular service runs across Ballina Shire.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/limpinwood.md
+++ b/content/locations/limpinwood.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Limpinwood | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Limpinwood for homes and businesses. Same or next-day service across Tweed Valley."
+description = "Licensed, eco-conscious pest control in Limpinwood for homes and businesses. Visits are scheduled around regular service runs across Tweed Valley."
 keywords = [
   "Limpinwood pest control",
   "Tweed Valley termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Limpinwood. Same or next-day support across Tweed Valley.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Limpinwood. Support is booked around regular service runs across Tweed Valley.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/lismore-heights.md
+++ b/content/locations/lismore-heights.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Lismore Heights | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Lismore Heights for homes and businesses. Same or next-day service across Lismore Region."
+description = "Licensed, eco-conscious pest control in Lismore Heights for homes and businesses. Visits are scheduled around regular service runs across Lismore Region."
 keywords = [
   "Lismore Heights pest control",
   "Lismore Region termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Lismore Heights. Same or next-day support across Lismore Region.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Lismore Heights. Support is booked around regular service runs across Lismore Region.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/lismore.md
+++ b/content/locations/lismore.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Lismore | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Lismore for homes and businesses. Same or next-day service across Lismore Region."
+description = "Licensed, eco-conscious pest control in Lismore for homes and businesses. Visits are scheduled around regular service runs across Lismore Region."
 keywords = [
   "Lismore pest control",
   "Lismore Region termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Lismore. Same or next-day support across Lismore Region.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Lismore. Support is booked around regular service runs across Lismore Region.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/loftville.md
+++ b/content/locations/loftville.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Loftville | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Loftville for homes and businesses. Same or next-day service across Lismore Region."
+description = "Licensed, eco-conscious pest control in Loftville for homes and businesses. Visits are scheduled around regular service runs across Lismore Region."
 keywords = [
   "Loftville pest control",
   "Lismore Region termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Loftville. Same or next-day support across Lismore Region.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Loftville. Support is booked around regular service runs across Lismore Region.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/lynwood.md
+++ b/content/locations/lynwood.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Lynwood | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Lynwood for homes and businesses. Same or next-day service across Ballina Shire."
+description = "Licensed, eco-conscious pest control in Lynwood for homes and businesses. Visits are scheduled around regular service runs across Ballina Shire."
 keywords = [
   "Lynwood pest control",
   "Ballina Shire termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Lynwood. Same or next-day support across Ballina Shire.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Lynwood. Support is booked around regular service runs across Ballina Shire.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/main-arm.md
+++ b/content/locations/main-arm.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Main Arm | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Main Arm for homes and businesses. Same or next-day service across Byron Shire."
+description = "Licensed, eco-conscious pest control in Main Arm for homes and businesses. Visits are scheduled around regular service runs across Byron Shire."
 keywords = [
   "Main Arm pest control",
   "Byron Shire termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Main Arm. Same or next-day support across Byron Shire.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Main Arm. Support is booked around regular service runs across Byron Shire.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/mcleans-ridges.md
+++ b/content/locations/mcleans-ridges.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control McLeans Ridges | Local Pest Co"
-description = "Licensed, eco-conscious pest control in McLeans Ridges for homes and businesses. Same or next-day service across Ballina Shire."
+description = "Licensed, eco-conscious pest control in McLeans Ridges for homes and businesses. Visits are scheduled around regular service runs across Ballina Shire."
 keywords = [
   "McLeans Ridges pest control",
   "Ballina Shire termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in McLeans Ridges. Same or next-day support across Ballina Shire.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in McLeans Ridges. Support is booked around regular service runs across Ballina Shire.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/mcleods-shoot.md
+++ b/content/locations/mcleods-shoot.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control McLeods Shoot | Local Pest Co"
-description = "Licensed, eco-conscious pest control in McLeods Shoot for homes and businesses. Same or next-day service across Byron Shire."
+description = "Licensed, eco-conscious pest control in McLeods Shoot for homes and businesses. Visits are scheduled around regular service runs across Byron Shire."
 keywords = [
   "McLeods Shoot pest control",
   "Byron Shire termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in McLeods Shoot. Same or next-day support across Byron Shire.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in McLeods Shoot. Support is booked around regular service runs across Byron Shire.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/meerschaum-vale.md
+++ b/content/locations/meerschaum-vale.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Meerschaum Vale | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Meerschaum Vale for homes and businesses. Same or next-day service across Ballina Shire."
+description = "Licensed, eco-conscious pest control in Meerschaum Vale for homes and businesses. Visits are scheduled around regular service runs across Ballina Shire."
 keywords = [
   "Meerschaum Vale pest control",
   "Ballina Shire termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Meerschaum Vale. Same or next-day support across Ballina Shire.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Meerschaum Vale. Support is booked around regular service runs across Ballina Shire.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/middle-pocket.md
+++ b/content/locations/middle-pocket.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Middle Pocket | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Middle Pocket for homes and businesses. Same or next-day service across Byron Shire."
+description = "Licensed, eco-conscious pest control in Middle Pocket for homes and businesses. Visits are scheduled around regular service runs across Byron Shire."
 keywords = [
   "Middle Pocket pest control",
   "Byron Shire termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Middle Pocket. Same or next-day support across Byron Shire.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Middle Pocket. Support is booked around regular service runs across Byron Shire.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/midginbil.md
+++ b/content/locations/midginbil.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Midginbil | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Midginbil for homes and businesses. Same or next-day service across Tweed Valley."
+description = "Licensed, eco-conscious pest control in Midginbil for homes and businesses. Visits are scheduled around regular service runs across Tweed Valley."
 keywords = [
   "Midginbil pest control",
   "Tweed Valley termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Midginbil. Same or next-day support across Tweed Valley.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Midginbil. Support is booked around regular service runs across Tweed Valley.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/modanville.md
+++ b/content/locations/modanville.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Modanville | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Modanville for homes and businesses. Same or next-day service across Lismore Region."
+description = "Licensed, eco-conscious pest control in Modanville for homes and businesses. Visits are scheduled around regular service runs across Lismore Region."
 keywords = [
   "Modanville pest control",
   "Lismore Region termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Modanville. Same or next-day support across Lismore Region.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Modanville. Support is booked around regular service runs across Lismore Region.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/mooball.md
+++ b/content/locations/mooball.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Mooball | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Mooball for homes and businesses. Same or next-day service across Tweed Valley."
+description = "Licensed, eco-conscious pest control in Mooball for homes and businesses. Visits are scheduled around regular service runs across Tweed Valley."
 keywords = [
   "Mooball pest control",
   "Tweed Valley termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Mooball. Same or next-day support across Tweed Valley.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Mooball. Support is booked around regular service runs across Tweed Valley.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/mount-burrell.md
+++ b/content/locations/mount-burrell.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Mount Burrell | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Mount Burrell for homes and businesses. Same or next-day service across Tweed Valley."
+description = "Licensed, eco-conscious pest control in Mount Burrell for homes and businesses. Visits are scheduled around regular service runs across Tweed Valley."
 keywords = [
   "Mount Burrell pest control",
   "Tweed Valley termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Mount Burrell. Same or next-day support across Tweed Valley.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Mount Burrell. Support is booked around regular service runs across Tweed Valley.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/mullumbimby-creek.md
+++ b/content/locations/mullumbimby-creek.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Mullumbimby Creek | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Mullumbimby Creek for homes and businesses. Same or next-day service across Byron Shire."
+description = "Licensed, eco-conscious pest control in Mullumbimby Creek for homes and businesses. Visits are scheduled around regular service runs across Byron Shire."
 keywords = [
   "Mullumbimby Creek pest control",
   "Byron Shire termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Mullumbimby Creek. Same or next-day support across Byron Shire.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Mullumbimby Creek. Support is booked around regular service runs across Byron Shire.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/mullumbimby.md
+++ b/content/locations/mullumbimby.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Mullumbimby | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Mullumbimby for homes and businesses. Same or next-day service across Byron Shire."
+description = "Licensed, eco-conscious pest control in Mullumbimby for homes and businesses. Visits are scheduled around regular service runs across Byron Shire."
 keywords = [
   "Mullumbimby pest control",
   "Byron Shire termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Mullumbimby. Same or next-day support across Byron Shire.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Mullumbimby. Support is booked around regular service runs across Byron Shire.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/murwillumbah.md
+++ b/content/locations/murwillumbah.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Murwillumbah | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Murwillumbah for homes and businesses. Same or next-day service across Tweed Valley."
+description = "Licensed, eco-conscious pest control in Murwillumbah for homes and businesses. Visits are scheduled around regular service runs across Tweed Valley."
 keywords = [
   "Murwillumbah pest control",
   "Tweed Valley termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Murwillumbah. Same or next-day support across Tweed Valley.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Murwillumbah. Support is booked around regular service runs across Tweed Valley.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/nashua.md
+++ b/content/locations/nashua.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Nashua | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Nashua for homes and businesses. Same or next-day service across Byron Shire."
+description = "Licensed, eco-conscious pest control in Nashua for homes and businesses. Visits are scheduled around regular service runs across Byron Shire."
 keywords = [
   "Nashua pest control",
   "Byron Shire termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Nashua. Same or next-day support across Byron Shire.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Nashua. Support is booked around regular service runs across Byron Shire.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/new-brighton.md
+++ b/content/locations/new-brighton.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control New Brighton | Local Pest Co"
-description = "Licensed, eco-conscious pest control in New Brighton for homes and businesses. Same or next-day service across Byron Shire."
+description = "Licensed, eco-conscious pest control in New Brighton for homes and businesses. Visits are scheduled around regular service runs across Byron Shire."
 keywords = [
   "New Brighton pest control",
   "Byron Shire termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in New Brighton. Same or next-day support across Byron Shire.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in New Brighton. Support is booked around regular service runs across Byron Shire.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/newrybar.md
+++ b/content/locations/newrybar.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Newrybar | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Newrybar for homes and businesses. Same or next-day service across Ballina Shire."
+description = "Licensed, eco-conscious pest control in Newrybar for homes and businesses. Visits are scheduled around regular service runs across Ballina Shire."
 keywords = [
   "Newrybar pest control",
   "Ballina Shire termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Newrybar. Same or next-day support across Ballina Shire.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Newrybar. Support is booked around regular service runs across Ballina Shire.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/nobbys-creek.md
+++ b/content/locations/nobbys-creek.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Nobbys Creek | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Nobbys Creek for homes and businesses. Same or next-day service across Tweed Valley."
+description = "Licensed, eco-conscious pest control in Nobbys Creek for homes and businesses. Visits are scheduled around regular service runs across Tweed Valley."
 keywords = [
   "Nobbys Creek pest control",
   "Tweed Valley termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Nobbys Creek. Same or next-day support across Tweed Valley.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Nobbys Creek. Support is booked around regular service runs across Tweed Valley.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/north-lismore.md
+++ b/content/locations/north-lismore.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control North Lismore | Local Pest Co"
-description = "Licensed, eco-conscious pest control in North Lismore for homes and businesses. Same or next-day service across Lismore Region."
+description = "Licensed, eco-conscious pest control in North Lismore for homes and businesses. Visits are scheduled around regular service runs across Lismore Region."
 keywords = [
   "North Lismore pest control",
   "Lismore Region termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in North Lismore. Same or next-day support across Lismore Region.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in North Lismore. Support is booked around regular service runs across Lismore Region.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/north-tumbulgum.md
+++ b/content/locations/north-tumbulgum.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control North Tumbulgum | Local Pest Co"
-description = "Licensed, eco-conscious pest control in North Tumbulgum for homes and businesses. Same or next-day service across Tweed Valley."
+description = "Licensed, eco-conscious pest control in North Tumbulgum for homes and businesses. Visits are scheduled around regular service runs across Tweed Valley."
 keywords = [
   "North Tumbulgum pest control",
   "Tweed Valley termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in North Tumbulgum. Same or next-day support across Tweed Valley.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in North Tumbulgum. Support is booked around regular service runs across Tweed Valley.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/ocean-shores.md
+++ b/content/locations/ocean-shores.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Ocean Shores | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Ocean Shores for homes and businesses. Same or next-day service across Byron Shire."
+description = "Licensed, eco-conscious pest control in Ocean Shores for homes and businesses. Visits are scheduled around regular service runs across Byron Shire."
 keywords = [
   "Ocean Shores pest control",
   "Byron Shire termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Ocean Shores. Same or next-day support across Byron Shire.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Ocean Shores. Support is booked around regular service runs across Byron Shire.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/palmvale.md
+++ b/content/locations/palmvale.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Palmvale | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Palmvale for homes and businesses. Same or next-day service across Tweed Valley."
+description = "Licensed, eco-conscious pest control in Palmvale for homes and businesses. Visits are scheduled around regular service runs across Tweed Valley."
 keywords = [
   "Palmvale pest control",
   "Tweed Valley termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Palmvale. Same or next-day support across Tweed Valley.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Palmvale. Support is booked around regular service runs across Tweed Valley.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/palmwoods.md
+++ b/content/locations/palmwoods.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Palmwoods | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Palmwoods for homes and businesses. Same or next-day service across Byron Shire."
+description = "Licensed, eco-conscious pest control in Palmwoods for homes and businesses. Visits are scheduled around regular service runs across Byron Shire."
 keywords = [
   "Palmwoods pest control",
   "Byron Shire termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Palmwoods. Same or next-day support across Byron Shire.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Palmwoods. Support is booked around regular service runs across Byron Shire.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/patchs-beach.md
+++ b/content/locations/patchs-beach.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Patchs Beach | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Patchs Beach for homes and businesses. Same or next-day service across Ballina Shire."
+description = "Licensed, eco-conscious pest control in Patchs Beach for homes and businesses. Visits are scheduled around regular service runs across Ballina Shire."
 keywords = [
   "Patchs Beach pest control",
   "Ballina Shire termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Patchs Beach. Same or next-day support across Ballina Shire.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Patchs Beach. Support is booked around regular service runs across Ballina Shire.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/pearces-creek.md
+++ b/content/locations/pearces-creek.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Pearces Creek | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Pearces Creek for homes and businesses. Same or next-day service across Ballina Shire."
+description = "Licensed, eco-conscious pest control in Pearces Creek for homes and businesses. Visits are scheduled around regular service runs across Ballina Shire."
 keywords = [
   "Pearces Creek pest control",
   "Ballina Shire termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Pearces Creek. Same or next-day support across Ballina Shire.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Pearces Creek. Support is booked around regular service runs across Ballina Shire.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/piggabeen.md
+++ b/content/locations/piggabeen.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Piggabeen | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Piggabeen for homes and businesses. Same or next-day service across Tweed Coast."
+description = "Licensed, eco-conscious pest control in Piggabeen for homes and businesses. Visits are scheduled around regular service runs across Tweed Coast."
 keywords = [
   "Piggabeen pest control",
   "Tweed Coast termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Piggabeen. Same or next-day support across Tweed Coast.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Piggabeen. Support is booked around regular service runs across Tweed Coast.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/pimlico.md
+++ b/content/locations/pimlico.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Pimlico | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Pimlico for homes and businesses. Same or next-day service across Ballina Shire."
+description = "Licensed, eco-conscious pest control in Pimlico for homes and businesses. Visits are scheduled around regular service runs across Ballina Shire."
 keywords = [
   "Pimlico pest control",
   "Ballina Shire termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Pimlico. Same or next-day support across Ballina Shire.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Pimlico. Support is booked around regular service runs across Ballina Shire.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/possum-creek.md
+++ b/content/locations/possum-creek.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Possum Creek | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Possum Creek for homes and businesses. Same or next-day service across Byron Shire."
+description = "Licensed, eco-conscious pest control in Possum Creek for homes and businesses. Visits are scheduled around regular service runs across Byron Shire."
 keywords = [
   "Possum Creek pest control",
   "Byron Shire termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Possum Creek. Same or next-day support across Byron Shire.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Possum Creek. Support is booked around regular service runs across Byron Shire.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/pottsville.md
+++ b/content/locations/pottsville.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Pottsville | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Pottsville for homes and businesses. Same or next-day service across Tweed Coast."
+description = "Licensed, eco-conscious pest control in Pottsville for homes and businesses. Visits are scheduled around regular service runs across Tweed Coast."
 keywords = [
   "Pottsville pest control",
   "Tweed Coast termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Pottsville. Same or next-day support across Tweed Coast.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Pottsville. Support is booked around regular service runs across Tweed Coast.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/reserve-creek.md
+++ b/content/locations/reserve-creek.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Reserve Creek | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Reserve Creek for homes and businesses. Same or next-day service across Tweed Valley."
+description = "Licensed, eco-conscious pest control in Reserve Creek for homes and businesses. Visits are scheduled around regular service runs across Tweed Valley."
 keywords = [
   "Reserve Creek pest control",
   "Tweed Valley termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Reserve Creek. Same or next-day support across Tweed Valley.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Reserve Creek. Support is booked around regular service runs across Tweed Valley.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/richmond-hill.md
+++ b/content/locations/richmond-hill.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Richmond Hill | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Richmond Hill for homes and businesses. Same or next-day service across Lismore Region."
+description = "Licensed, eco-conscious pest control in Richmond Hill for homes and businesses. Visits are scheduled around regular service runs across Lismore Region."
 keywords = [
   "Richmond Hill pest control",
   "Lismore Region termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Richmond Hill. Same or next-day support across Lismore Region.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Richmond Hill. Support is booked around regular service runs across Lismore Region.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/round-mountain.md
+++ b/content/locations/round-mountain.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Round Mountain | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Round Mountain for homes and businesses. Same or next-day service across Tweed Valley."
+description = "Licensed, eco-conscious pest control in Round Mountain for homes and businesses. Visits are scheduled around regular service runs across Tweed Valley."
 keywords = [
   "Round Mountain pest control",
   "Tweed Valley termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Round Mountain. Same or next-day support across Tweed Valley.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Round Mountain. Support is booked around regular service runs across Tweed Valley.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/rous-mill.md
+++ b/content/locations/rous-mill.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Rous Mill | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Rous Mill for homes and businesses. Same or next-day service across Ballina Shire."
+description = "Licensed, eco-conscious pest control in Rous Mill for homes and businesses. Visits are scheduled around regular service runs across Ballina Shire."
 keywords = [
   "Rous Mill pest control",
   "Ballina Shire termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Rous Mill. Same or next-day support across Ballina Shire.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Rous Mill. Support is booked around regular service runs across Ballina Shire.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/rous.md
+++ b/content/locations/rous.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Rous | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Rous for homes and businesses. Same or next-day service across Ballina Shire."
+description = "Licensed, eco-conscious pest control in Rous for homes and businesses. Visits are scheduled around regular service runs across Ballina Shire."
 keywords = [
   "Rous pest control",
   "Ballina Shire termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Rous. Same or next-day support across Ballina Shire.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Rous. Support is booked around regular service runs across Ballina Shire.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/rowlands-creek.md
+++ b/content/locations/rowlands-creek.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Rowlands Creek | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Rowlands Creek for homes and businesses. Same or next-day service across Tweed Valley."
+description = "Licensed, eco-conscious pest control in Rowlands Creek for homes and businesses. Visits are scheduled around regular service runs across Tweed Valley."
 keywords = [
   "Rowlands Creek pest control",
   "Tweed Valley termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Rowlands Creek. Same or next-day support across Tweed Valley.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Rowlands Creek. Support is booked around regular service runs across Tweed Valley.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/skennars-head.md
+++ b/content/locations/skennars-head.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Skennars Head | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Skennars Head for homes and businesses. Same or next-day service across Ballina Shire."
+description = "Licensed, eco-conscious pest control in Skennars Head for homes and businesses. Visits are scheduled around regular service runs across Ballina Shire."
 keywords = [
   "Skennars Head pest control",
   "Ballina Shire termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Skennars Head. Same or next-day support across Ballina Shire.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Skennars Head. Support is booked around regular service runs across Ballina Shire.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/skinners-shoot.md
+++ b/content/locations/skinners-shoot.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Skinners Shoot | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Skinners Shoot for homes and businesses. Same or next-day service across Byron Shire."
+description = "Licensed, eco-conscious pest control in Skinners Shoot for homes and businesses. Visits are scheduled around regular service runs across Byron Shire."
 keywords = [
   "Skinners Shoot pest control",
   "Byron Shire termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Skinners Shoot. Same or next-day support across Byron Shire.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Skinners Shoot. Support is booked around regular service runs across Byron Shire.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/sleepy-hollow.md
+++ b/content/locations/sleepy-hollow.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Sleepy Hollow | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Sleepy Hollow for homes and businesses. Same or next-day service across Tweed Valley."
+description = "Licensed, eco-conscious pest control in Sleepy Hollow for homes and businesses. Visits are scheduled around regular service runs across Tweed Valley."
 keywords = [
   "Sleepy Hollow pest control",
   "Tweed Valley termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Sleepy Hollow. Same or next-day support across Tweed Valley.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Sleepy Hollow. Support is booked around regular service runs across Tweed Valley.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/smiths-creek.md
+++ b/content/locations/smiths-creek.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Smiths Creek | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Smiths Creek for homes and businesses. Same or next-day service across Tweed Valley."
+description = "Licensed, eco-conscious pest control in Smiths Creek for homes and businesses. Visits are scheduled around regular service runs across Tweed Valley."
 keywords = [
   "Smiths Creek pest control",
   "Tweed Valley termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Smiths Creek. Same or next-day support across Tweed Valley.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Smiths Creek. Support is booked around regular service runs across Tweed Valley.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/south-ballina.md
+++ b/content/locations/south-ballina.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control South Ballina | Local Pest Co"
-description = "Licensed, eco-conscious pest control in South Ballina for homes and businesses. Same or next-day service across Ballina Shire."
+description = "Licensed, eco-conscious pest control in South Ballina for homes and businesses. Visits are scheduled around regular service runs across Ballina Shire."
 keywords = [
   "South Ballina pest control",
   "Ballina Shire termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in South Ballina. Same or next-day support across Ballina Shire.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in South Ballina. Support is booked around regular service runs across Ballina Shire.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/south-golden-beach.md
+++ b/content/locations/south-golden-beach.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control South Golden Beach | Local Pest Co"
-description = "Licensed, eco-conscious pest control in South Golden Beach for homes and businesses. Same or next-day service across Byron Shire."
+description = "Licensed, eco-conscious pest control in South Golden Beach for homes and businesses. Visits are scheduled around regular service runs across Byron Shire."
 keywords = [
   "South Golden Beach pest control",
   "Byron Shire termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in South Golden Beach. Same or next-day support across Byron Shire.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in South Golden Beach. Support is booked around regular service runs across Byron Shire.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/south-lismore.md
+++ b/content/locations/south-lismore.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control South Lismore | Local Pest Co"
-description = "Licensed, eco-conscious pest control in South Lismore for homes and businesses. Same or next-day service across Lismore Region."
+description = "Licensed, eco-conscious pest control in South Lismore for homes and businesses. Visits are scheduled around regular service runs across Lismore Region."
 keywords = [
   "South Lismore pest control",
   "Lismore Region termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in South Lismore. Same or next-day support across Lismore Region.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in South Lismore. Support is booked around regular service runs across Lismore Region.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/south-murwillumbah.md
+++ b/content/locations/south-murwillumbah.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control South Murwillumbah | Local Pest Co"
-description = "Licensed, eco-conscious pest control in South Murwillumbah for homes and businesses. Same or next-day service across Tweed Valley."
+description = "Licensed, eco-conscious pest control in South Murwillumbah for homes and businesses. Visits are scheduled around regular service runs across Tweed Valley."
 keywords = [
   "South Murwillumbah pest control",
   "Tweed Valley termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in South Murwillumbah. Same or next-day support across Tweed Valley.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in South Murwillumbah. Support is booked around regular service runs across Tweed Valley.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/stokers-siding.md
+++ b/content/locations/stokers-siding.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Stokers Siding | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Stokers Siding for homes and businesses. Same or next-day service across Tweed Valley."
+description = "Licensed, eco-conscious pest control in Stokers Siding for homes and businesses. Visits are scheduled around regular service runs across Tweed Valley."
 keywords = [
   "Stokers Siding pest control",
   "Tweed Valley termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Stokers Siding. Same or next-day support across Tweed Valley.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Stokers Siding. Support is booked around regular service runs across Tweed Valley.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/suffolk-park.md
+++ b/content/locations/suffolk-park.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Suffolk Park | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Suffolk Park for homes and businesses. Same or next-day service across Byron Shire."
+description = "Licensed, eco-conscious pest control in Suffolk Park for homes and businesses. Visits are scheduled around regular service runs across Byron Shire."
 keywords = [
   "Suffolk Park pest control",
   "Byron Shire termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Suffolk Park. Same or next-day support across Byron Shire.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Suffolk Park. Support is booked around regular service runs across Byron Shire.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/talofa.md
+++ b/content/locations/talofa.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Talofa | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Talofa for homes and businesses. Same or next-day service across Byron Shire."
+description = "Licensed, eco-conscious pest control in Talofa for homes and businesses. Visits are scheduled around regular service runs across Byron Shire."
 keywords = [
   "Talofa pest control",
   "Byron Shire termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Talofa. Same or next-day support across Byron Shire.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Talofa. Support is booked around regular service runs across Byron Shire.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/tanglewood.md
+++ b/content/locations/tanglewood.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Tanglewood | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Tanglewood for homes and businesses. Same or next-day service across Tweed Valley."
+description = "Licensed, eco-conscious pest control in Tanglewood for homes and businesses. Visits are scheduled around regular service runs across Tweed Valley."
 keywords = [
   "Tanglewood pest control",
   "Tweed Valley termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Tanglewood. Same or next-day support across Tweed Valley.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Tanglewood. Support is booked around regular service runs across Tweed Valley.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/terranora.md
+++ b/content/locations/terranora.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Terranora | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Terranora for homes and businesses. Same or next-day service across Tweed Coast."
+description = "Licensed, eco-conscious pest control in Terranora for homes and businesses. Visits are scheduled around regular service runs across Tweed Coast."
 keywords = [
   "Terranora pest control",
   "Tweed Coast termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Terranora. Same or next-day support across Tweed Coast.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Terranora. Support is booked around regular service runs across Tweed Coast.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/teven.md
+++ b/content/locations/teven.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Teven | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Teven for homes and businesses. Same or next-day service across Ballina Shire."
+description = "Licensed, eco-conscious pest control in Teven for homes and businesses. Visits are scheduled around regular service runs across Ballina Shire."
 keywords = [
   "Teven pest control",
   "Ballina Shire termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Teven. Same or next-day support across Ballina Shire.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Teven. Support is booked around regular service runs across Ballina Shire.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/the-pocket.md
+++ b/content/locations/the-pocket.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control The Pocket | Local Pest Co"
-description = "Licensed, eco-conscious pest control in The Pocket for homes and businesses. Same or next-day service across Byron Shire."
+description = "Licensed, eco-conscious pest control in The Pocket for homes and businesses. Visits are scheduled around regular service runs across Byron Shire."
 keywords = [
   "The Pocket pest control",
   "Byron Shire termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in The Pocket. Same or next-day support across Byron Shire.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in The Pocket. Support is booked around regular service runs across Byron Shire.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/tintenbar.md
+++ b/content/locations/tintenbar.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Tintenbar | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Tintenbar for homes and businesses. Same or next-day service across Ballina Shire."
+description = "Licensed, eco-conscious pest control in Tintenbar for homes and businesses. Visits are scheduled around regular service runs across Ballina Shire."
 keywords = [
   "Tintenbar pest control",
   "Ballina Shire termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Tintenbar. Same or next-day support across Ballina Shire.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Tintenbar. Support is booked around regular service runs across Ballina Shire.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/tomewin.md
+++ b/content/locations/tomewin.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Tomewin | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Tomewin for homes and businesses. Same or next-day service across Tweed Valley."
+description = "Licensed, eco-conscious pest control in Tomewin for homes and businesses. Visits are scheduled around regular service runs across Tweed Valley."
 keywords = [
   "Tomewin pest control",
   "Tweed Valley termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Tomewin. Same or next-day support across Tweed Valley.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Tomewin. Support is booked around regular service runs across Tweed Valley.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/tregeagle.md
+++ b/content/locations/tregeagle.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Tregeagle | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Tregeagle for homes and businesses. Same or next-day service across Lismore Region."
+description = "Licensed, eco-conscious pest control in Tregeagle for homes and businesses. Visits are scheduled around regular service runs across Lismore Region."
 keywords = [
   "Tregeagle pest control",
   "Lismore Region termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Tregeagle. Same or next-day support across Lismore Region.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Tregeagle. Support is booked around regular service runs across Lismore Region.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/tucki-tucki.md
+++ b/content/locations/tucki-tucki.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Tucki Tucki | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Tucki Tucki for homes and businesses. Same or next-day service across Lismore Region."
+description = "Licensed, eco-conscious pest control in Tucki Tucki for homes and businesses. Visits are scheduled around regular service runs across Lismore Region."
 keywords = [
   "Tucki Tucki pest control",
   "Lismore Region termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Tucki Tucki. Same or next-day support across Lismore Region.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Tucki Tucki. Support is booked around regular service runs across Lismore Region.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/tumbulgum.md
+++ b/content/locations/tumbulgum.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Tumbulgum | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Tumbulgum for homes and businesses. Same or next-day service across Tweed Valley."
+description = "Licensed, eco-conscious pest control in Tumbulgum for homes and businesses. Visits are scheduled around regular service runs across Tweed Valley."
 keywords = [
   "Tumbulgum pest control",
   "Tweed Valley termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Tumbulgum. Same or next-day support across Tweed Valley.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Tumbulgum. Support is booked around regular service runs across Tweed Valley.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/tweed-heads-south.md
+++ b/content/locations/tweed-heads-south.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Tweed Heads South | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Tweed Heads South for homes and businesses. Same or next-day service across Tweed Coast."
+description = "Licensed, eco-conscious pest control in Tweed Heads South for homes and businesses. Visits are scheduled around regular service runs across Tweed Coast."
 keywords = [
   "Tweed Heads South pest control",
   "Tweed Coast termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Tweed Heads South. Same or next-day support across Tweed Coast.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Tweed Heads South. Support is booked around regular service runs across Tweed Coast.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/tweed-heads-west.md
+++ b/content/locations/tweed-heads-west.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Tweed Heads West | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Tweed Heads West for homes and businesses. Same or next-day service across Tweed Coast."
+description = "Licensed, eco-conscious pest control in Tweed Heads West for homes and businesses. Visits are scheduled around regular service runs across Tweed Coast."
 keywords = [
   "Tweed Heads West pest control",
   "Tweed Coast termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Tweed Heads West. Same or next-day support across Tweed Coast.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Tweed Heads West. Support is booked around regular service runs across Tweed Coast.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/tweed-heads.md
+++ b/content/locations/tweed-heads.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Tweed Heads | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Tweed Heads for homes and businesses. Same or next-day service across Tweed Coast."
+description = "Licensed, eco-conscious pest control in Tweed Heads for homes and businesses. Visits are scheduled around regular service runs across Tweed Coast."
 keywords = [
   "Tweed Heads pest control",
   "Tweed Coast termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Tweed Heads. Same or next-day support across Tweed Coast.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Tweed Heads. Support is booked around regular service runs across Tweed Coast.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/tyagarah.md
+++ b/content/locations/tyagarah.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Tyagarah | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Tyagarah for homes and businesses. Same or next-day service across Byron Shire."
+description = "Licensed, eco-conscious pest control in Tyagarah for homes and businesses. Visits are scheduled around regular service runs across Byron Shire."
 keywords = [
   "Tyagarah pest control",
   "Byron Shire termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Tyagarah. Same or next-day support across Byron Shire.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Tyagarah. Support is booked around regular service runs across Byron Shire.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/tyalgum-creek.md
+++ b/content/locations/tyalgum-creek.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Tyalgum Creek | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Tyalgum Creek for homes and businesses. Same or next-day service across Tweed Valley."
+description = "Licensed, eco-conscious pest control in Tyalgum Creek for homes and businesses. Visits are scheduled around regular service runs across Tweed Valley."
 keywords = [
   "Tyalgum Creek pest control",
   "Tweed Valley termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Tyalgum Creek. Same or next-day support across Tweed Valley.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Tyalgum Creek. Support is booked around regular service runs across Tweed Valley.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/tyalgum.md
+++ b/content/locations/tyalgum.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Tyalgum | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Tyalgum for homes and businesses. Same or next-day service across Tweed Valley."
+description = "Licensed, eco-conscious pest control in Tyalgum for homes and businesses. Visits are scheduled around regular service runs across Tweed Valley."
 keywords = [
   "Tyalgum pest control",
   "Tweed Valley termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Tyalgum. Same or next-day support across Tweed Valley.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Tyalgum. Support is booked around regular service runs across Tweed Valley.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/tygalgah.md
+++ b/content/locations/tygalgah.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Tygalgah | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Tygalgah for homes and businesses. Same or next-day service across Tweed Valley."
+description = "Licensed, eco-conscious pest control in Tygalgah for homes and businesses. Visits are scheduled around regular service runs across Tweed Valley."
 keywords = [
   "Tygalgah pest control",
   "Tweed Valley termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Tygalgah. Same or next-day support across Tweed Valley.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Tygalgah. Support is booked around regular service runs across Tweed Valley.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/uki.md
+++ b/content/locations/uki.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Uki | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Uki for homes and businesses. Same or next-day service across Tweed Valley."
+description = "Licensed, eco-conscious pest control in Uki for homes and businesses. Visits are scheduled around regular service runs across Tweed Valley."
 keywords = [
   "Uki pest control",
   "Tweed Valley termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Uki. Same or next-day support across Tweed Valley.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Uki. Support is booked around regular service runs across Tweed Valley.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/upper-burringbar.md
+++ b/content/locations/upper-burringbar.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Upper Burringbar | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Upper Burringbar for homes and businesses. Same or next-day service across Tweed Valley."
+description = "Licensed, eco-conscious pest control in Upper Burringbar for homes and businesses. Visits are scheduled around regular service runs across Tweed Valley."
 keywords = [
   "Upper Burringbar pest control",
   "Tweed Valley termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Upper Burringbar. Same or next-day support across Tweed Valley.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Upper Burringbar. Support is booked around regular service runs across Tweed Valley.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/upper-coopers-creek.md
+++ b/content/locations/upper-coopers-creek.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Upper Coopers Creek | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Upper Coopers Creek for homes and businesses. Same or next-day service across Byron Shire."
+description = "Licensed, eco-conscious pest control in Upper Coopers Creek for homes and businesses. Visits are scheduled around regular service runs across Byron Shire."
 keywords = [
   "Upper Coopers Creek pest control",
   "Byron Shire termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Upper Coopers Creek. Same or next-day support across Byron Shire.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Upper Coopers Creek. Support is booked around regular service runs across Byron Shire.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/upper-crystal-creek.md
+++ b/content/locations/upper-crystal-creek.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Upper Crystal Creek | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Upper Crystal Creek for homes and businesses. Same or next-day service across Tweed Valley."
+description = "Licensed, eco-conscious pest control in Upper Crystal Creek for homes and businesses. Visits are scheduled around regular service runs across Tweed Valley."
 keywords = [
   "Upper Crystal Creek pest control",
   "Tweed Valley termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Upper Crystal Creek. Same or next-day support across Tweed Valley.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Upper Crystal Creek. Support is booked around regular service runs across Tweed Valley.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/upper-duroby.md
+++ b/content/locations/upper-duroby.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Upper Duroby | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Upper Duroby for homes and businesses. Same or next-day service across Tweed Valley."
+description = "Licensed, eco-conscious pest control in Upper Duroby for homes and businesses. Visits are scheduled around regular service runs across Tweed Valley."
 keywords = [
   "Upper Duroby pest control",
   "Tweed Valley termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Upper Duroby. Same or next-day support across Tweed Valley.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Upper Duroby. Support is booked around regular service runs across Tweed Valley.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/upper-main-arm.md
+++ b/content/locations/upper-main-arm.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Upper Main Arm | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Upper Main Arm for homes and businesses. Same or next-day service across Byron Shire."
+description = "Licensed, eco-conscious pest control in Upper Main Arm for homes and businesses. Visits are scheduled around regular service runs across Byron Shire."
 keywords = [
   "Upper Main Arm pest control",
   "Byron Shire termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Upper Main Arm. Same or next-day support across Byron Shire.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Upper Main Arm. Support is booked around regular service runs across Byron Shire.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/upper-wilsons-creek.md
+++ b/content/locations/upper-wilsons-creek.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Upper Wilsons Creek | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Upper Wilsons Creek for homes and businesses. Same or next-day service across Byron Shire."
+description = "Licensed, eco-conscious pest control in Upper Wilsons Creek for homes and businesses. Visits are scheduled around regular service runs across Byron Shire."
 keywords = [
   "Upper Wilsons Creek pest control",
   "Byron Shire termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Upper Wilsons Creek. Same or next-day support across Byron Shire.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Upper Wilsons Creek. Support is booked around regular service runs across Byron Shire.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/uralba.md
+++ b/content/locations/uralba.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Uralba | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Uralba for homes and businesses. Same or next-day service across Ballina Shire."
+description = "Licensed, eco-conscious pest control in Uralba for homes and businesses. Visits are scheduled around regular service runs across Ballina Shire."
 keywords = [
   "Uralba pest control",
   "Ballina Shire termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Uralba. Same or next-day support across Ballina Shire.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Uralba. Support is booked around regular service runs across Ballina Shire.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/urliup.md
+++ b/content/locations/urliup.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Urliup | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Urliup for homes and businesses. Same or next-day service across Tweed Valley."
+description = "Licensed, eco-conscious pest control in Urliup for homes and businesses. Visits are scheduled around regular service runs across Tweed Valley."
 keywords = [
   "Urliup pest control",
   "Tweed Valley termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Urliup. Same or next-day support across Tweed Valley.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Urliup. Support is booked around regular service runs across Tweed Valley.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/wanganui.md
+++ b/content/locations/wanganui.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Wanganui | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Wanganui for homes and businesses. Same or next-day service across Byron Shire."
+description = "Licensed, eco-conscious pest control in Wanganui for homes and businesses. Visits are scheduled around regular service runs across Byron Shire."
 keywords = [
   "Wanganui pest control",
   "Byron Shire termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Wanganui. Same or next-day support across Byron Shire.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Wanganui. Support is booked around regular service runs across Byron Shire.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/wardell.md
+++ b/content/locations/wardell.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Wardell | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Wardell for homes and businesses. Same or next-day service across Ballina Shire."
+description = "Licensed, eco-conscious pest control in Wardell for homes and businesses. Visits are scheduled around regular service runs across Ballina Shire."
 keywords = [
   "Wardell pest control",
   "Ballina Shire termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Wardell. Same or next-day support across Ballina Shire.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Wardell. Support is booked around regular service runs across Ballina Shire.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/wardrop-valley.md
+++ b/content/locations/wardrop-valley.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Wardrop Valley | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Wardrop Valley for homes and businesses. Same or next-day service across Tweed Valley."
+description = "Licensed, eco-conscious pest control in Wardrop Valley for homes and businesses. Visits are scheduled around regular service runs across Tweed Valley."
 keywords = [
   "Wardrop Valley pest control",
   "Tweed Valley termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Wardrop Valley. Same or next-day support across Tweed Valley.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Wardrop Valley. Support is booked around regular service runs across Tweed Valley.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/west-ballina.md
+++ b/content/locations/west-ballina.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control West Ballina | Local Pest Co"
-description = "Licensed, eco-conscious pest control in West Ballina for homes and businesses. Same or next-day service across Ballina Shire."
+description = "Licensed, eco-conscious pest control in West Ballina for homes and businesses. Visits are scheduled around regular service runs across Ballina Shire."
 keywords = [
   "West Ballina pest control",
   "Ballina Shire termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in West Ballina. Same or next-day support across Ballina Shire.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in West Ballina. Support is booked around regular service runs across Ballina Shire.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/wilsons-creek.md
+++ b/content/locations/wilsons-creek.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Wilsons Creek | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Wilsons Creek for homes and businesses. Same or next-day service across Byron Shire."
+description = "Licensed, eco-conscious pest control in Wilsons Creek for homes and businesses. Visits are scheduled around regular service runs across Byron Shire."
 keywords = [
   "Wilsons Creek pest control",
   "Byron Shire termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Wilsons Creek. Same or next-day support across Byron Shire.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Wilsons Creek. Support is booked around regular service runs across Byron Shire.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/wollongbar.md
+++ b/content/locations/wollongbar.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Wollongbar | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Wollongbar for homes and businesses. Same or next-day service across Ballina Shire."
+description = "Licensed, eco-conscious pest control in Wollongbar for homes and businesses. Visits are scheduled around regular service runs across Ballina Shire."
 keywords = [
   "Wollongbar pest control",
   "Ballina Shire termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Wollongbar. Same or next-day support across Ballina Shire.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Wollongbar. Support is booked around regular service runs across Ballina Shire.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/wollumbin-mount-warning.md
+++ b/content/locations/wollumbin-mount-warning.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Wollumbin (Mount Warning) | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Wollumbin (Mount Warning) for homes and businesses. Same or next-day service across Tweed Valley."
+description = "Licensed, eco-conscious pest control in Wollumbin (Mount Warning) for homes and businesses. Visits are scheduled around regular service runs across Tweed Valley."
 keywords = [
   "Wollumbin (Mount Warning) pest control",
   "Tweed Valley termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Wollumbin (Mount Warning). Same or next-day support across Tweed Valley.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Wollumbin (Mount Warning). Support is booked around regular service runs across Tweed Valley.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/wooyung.md
+++ b/content/locations/wooyung.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Wooyung | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Wooyung for homes and businesses. Same or next-day service across Tweed Coast."
+description = "Licensed, eco-conscious pest control in Wooyung for homes and businesses. Visits are scheduled around regular service runs across Tweed Coast."
 keywords = [
   "Wooyung pest control",
   "Tweed Coast termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Wooyung. Same or next-day support across Tweed Coast.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Wooyung. Support is booked around regular service runs across Tweed Coast.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/wyrallah.md
+++ b/content/locations/wyrallah.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Wyrallah | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Wyrallah for homes and businesses. Same or next-day service across Lismore Region."
+description = "Licensed, eco-conscious pest control in Wyrallah for homes and businesses. Visits are scheduled around regular service runs across Lismore Region."
 keywords = [
   "Wyrallah pest control",
   "Lismore Region termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Wyrallah. Same or next-day support across Lismore Region.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Wyrallah. Support is booked around regular service runs across Lismore Region.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/yelgun.md
+++ b/content/locations/yelgun.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Yelgun | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Yelgun for homes and businesses. Same or next-day service across Byron Shire."
+description = "Licensed, eco-conscious pest control in Yelgun for homes and businesses. Visits are scheduled around regular service runs across Byron Shire."
 keywords = [
   "Yelgun pest control",
   "Byron Shire termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Yelgun. Same or next-day support across Byron Shire.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Yelgun. Support is booked around regular service runs across Byron Shire.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/locations/zara.md
+++ b/content/locations/zara.md
@@ -1,6 +1,6 @@
 +++
 title = "Pest Control Zara | Local Pest Co"
-description = "Licensed, eco-conscious pest control in Zara for homes and businesses. Same or next-day service across Tweed Valley."
+description = "Licensed, eco-conscious pest control in Zara for homes and businesses. Visits are scheduled around regular service runs across Tweed Valley."
 keywords = [
   "Zara pest control",
   "Tweed Valley termite treatment",
@@ -18,7 +18,7 @@ answer = "Yes. I use targeted, low-tox options and explain what each product doe
 
 [[faq]]
 question = "How soon can you visit my place?"
-answer = "Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated."
+answer = "Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan."
 
 [[faq]]
 question = "Do you handle termites?"
@@ -34,7 +34,7 @@ answer = "Tidy access to affected rooms and move pets to a safe area. Let me kno
 +++
 {{< seo_h1 >}}
 
-Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Zara. Same or next-day support across Tweed Valley.
+Licensed NSW EPA pest management technician (Lic. 5073077) delivering targeted, low-tox treatments for homes and businesses in Zara. Support is booked around regular service runs across Tweed Valley.
 
 [Call 0405 508 035](tel:0405508035) — Book with Shannon.  
 [Email for a quote](mailto:thelocalpestco@bigpond.com) — Reply within one business day.

--- a/content/services.md
+++ b/content/services.md
@@ -18,7 +18,7 @@ answer = "I use targeted, low-toxicity treatments tailored to each pest problem.
 
 [[faq]]
 question = "Do you provide same-day service?"
-answer = "Yes, I strive to offer same-day or next-day visits across the Tweed Coast."
+answer = "I book jobs into planned runs across the Tweed Coast and will confirm the first available slot when you call or email."
 +++
 
 {{< seo_h1 >}}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,6 +1,13 @@
 {{ define "main" }}
 <article>
   {{ .Content }}
+  {{ if or (eq .Section "locations") (.Params.service) }}
+  <section class="booking-note">
+    <h2>Booking &amp; Service Frequency</h2>
+    <p>Work is booked into existing service runs so I can cover each area efficiently, which means it isn&rsquo;t always possible to attend the very next day. I&rsquo;ll confirm the first available appointment and keep you posted if weather or other jobs shift the schedule.</p>
+    <p>One-off treatments are possible when the timetable allows, yet most clients save money with planned follow-up visits that stop pests from re-establishing and reduce the need for heavier treatments later.</p>
+  </section>
+  {{ end }}
 </article>
 {{ partial "faq.html" . }}
 {{ with site.RegularPages.Related . }}

--- a/scripts/update_scheduling.py
+++ b/scripts/update_scheduling.py
@@ -1,0 +1,34 @@
+from pathlib import Path
+
+location_dir = Path('content/locations')
+for path in location_dir.glob('*.md'):
+    text = path.read_text()
+    updated = text
+    updated = updated.replace(
+        'Same or next-day service across',
+        'Visits are scheduled around regular service runs across'
+    )
+    updated = updated.replace(
+        'Same or next-day support across',
+        'Support is booked around regular service runs across'
+    )
+    updated = updated.replace(
+        'Most jobs happen the same or next day. I’ll confirm timing when you call or email. If weather slows things down, I’ll keep you updated.',
+        'Bookings are slotted into my existing run so I can cover the region efficiently. I’ll confirm the first available time when you call or email and keep you updated if weather or other jobs shift the plan.'
+    )
+    updated = updated.replace(
+        'I aim to provide same or next-day service where possible.',
+        'I schedule work around existing runs and will let you know the first available time when you get in touch.'
+    )
+    if updated != text:
+        path.write_text(updated)
+
+services_page = Path('content/services.md')
+if services_page.exists():
+    text = services_page.read_text()
+    updated = text.replace(
+        'Yes, I strive to offer same-day or next-day visits across the Tweed Coast.',
+        'I book jobs into planned runs across the Tweed Coast and will confirm the first available slot when you call or email.'
+    )
+    if updated != text:
+        services_page.write_text(updated)


### PR DESCRIPTION
## Summary
- replace same or next-day promises on all location pages with language about scheduling work around existing runs
- add a booking and service frequency note to location and service layouts promoting planned follow-up visits
- adjust the services FAQ answer and add a helper script used to update the markdown files

## Testing
- hugo --gc --minify *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d0e4e833b08325b60e50f2d13a1607